### PR TITLE
✨ feat : 기부희망댓글 등록, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/needit/common/domain/dto/CommentRequest.java
+++ b/src/main/java/com/prgrms/needit/common/domain/dto/CommentRequest.java
@@ -1,0 +1,29 @@
+package com.prgrms.needit.common.domain.dto;
+
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import com.prgrms.needit.domain.center.entity.Center;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentRequest {
+
+	@NotBlank(message = "댓글을 입력해주세요")
+	private String comment;
+
+	public CommentRequest(String comment) {
+		this.comment = comment;
+	}
+
+	public DonationComment toEntity(Center center, Donation donation) {
+		return DonationComment.builder()
+							  .comment(comment)
+							  .donation(donation)
+							  .center(center)
+							  .build();
+	}
+
+}

--- a/src/main/java/com/prgrms/needit/common/domain/entity/BaseEntity.java
+++ b/src/main/java/com/prgrms/needit/common/domain/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.prgrms.needit.common.domain;
+package com.prgrms.needit.common.domain.entity;
 
 import java.time.LocalDateTime;
 import javax.persistence.Column;

--- a/src/main/java/com/prgrms/needit/common/domain/entity/ThemeTag.java
+++ b/src/main/java/com/prgrms/needit/common/domain/entity/ThemeTag.java
@@ -1,4 +1,4 @@
-package com.prgrms.needit.common.domain;
+package com.prgrms.needit.common.domain.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
+++ b/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
@@ -7,11 +7,13 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(500, "C001", "정의되지 않은 에러가 발생했습니다."),
 	INVALID_INPUT_VALUE(400, "C002", "올바른 입력 형식이 아닙니다."),
 	NOT_MATCH_WRITER(400, "D003", "게시글의 작성자가 아닙니다."),
+	NOT_MATCH_COMMENT(400, "C004", "게시글의 댓글이 아닙니다."),
 
 	NOT_FOUND_DONATION(404, "D001", "존재하지 않는 기부글입니다."),
 	INVALID_CATEGORY_VALUE(400, "D002", "잘못된 카테고리 타입입니다."),
 	INVALID_QUALITY_VALUE(400, "D003", "잘못된 품질상태 타입입니다."),
-	INVALID_STATUS_VALUE(400, "D004", "잘못된 거래상태 타입입니다.");
+	INVALID_STATUS_VALUE(400, "D004", "잘못된 거래상태 타입입니다."),
+	NOT_FOUND_WISH_COMMENT(404, "D005", "존재하지 않는 기부희망댓글입니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/prgrms/needit/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/needit/common/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.prgrms.needit.common.error;
 
 import com.prgrms.needit.common.error.exception.InvalidArgumentException;
 import com.prgrms.needit.common.error.exception.NotFoundResourceException;
+import com.prgrms.needit.common.error.exception.NotMatchCommentException;
 import com.prgrms.needit.common.error.exception.NotMatchWriterException;
 import com.prgrms.needit.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,16 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NotMatchWriterException.class)
 	public ResponseEntity<ErrorResponse> NotMatchWriterExceptionHandler(NotMatchWriterException ex) {
+		log.error("Exception : " + ex.getMessage());
+		ErrorResponse response = ErrorResponse.of(
+			ex.getErrorCode()
+		);
+
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(NotMatchCommentException.class)
+	public ResponseEntity<ErrorResponse> NotMatchCommentExceptionHandler(NotMatchCommentException ex) {
 		log.error("Exception : " + ex.getMessage());
 		ErrorResponse response = ErrorResponse.of(
 			ex.getErrorCode()

--- a/src/main/java/com/prgrms/needit/common/error/exception/NotMatchCommentException.java
+++ b/src/main/java/com/prgrms/needit/common/error/exception/NotMatchCommentException.java
@@ -1,0 +1,15 @@
+package com.prgrms.needit.common.error.exception;
+
+import com.prgrms.needit.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotMatchCommentException extends RuntimeException {
+
+	private ErrorCode errorCode;
+
+	public NotMatchCommentException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/activity/entity/Activity.java
+++ b/src/main/java/com/prgrms/needit/domain/board/activity/entity/Activity.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.activity.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.center.entity.Center;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/board/activity/entity/ActivityComment.java
+++ b/src/main/java/com/prgrms/needit/domain/board/activity/entity/ActivityComment.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.activity.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/board/activity/entity/ActivityImage.java
+++ b/src/main/java/com/prgrms/needit/domain/board/activity/entity/ActivityImage.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.activity.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -70,4 +70,12 @@ public class DonationController {
 		return ResponseEntity.ok(ApiResponse.of(commentService.registerComment(id, request)));
 	}
 
+	@DeleteMapping("/{donationId}/comments/{commentId}")
+	public ResponseEntity<Void> removeComment(
+		@PathVariable Long donationId,
+		@PathVariable Long commentId
+	) {
+		commentService.removeComment(donationId, commentId);
+		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+	}
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -1,8 +1,10 @@
 package com.prgrms.needit.domain.board.donation.controller;
 
+import com.prgrms.needit.common.domain.dto.CommentRequest;
 import com.prgrms.needit.common.response.ApiResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
+import com.prgrms.needit.domain.board.donation.service.CommentService;
 import com.prgrms.needit.domain.board.donation.service.DonationService;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -21,9 +23,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class DonationController {
 
 	private final DonationService donationService;
+	private final CommentService commentService;
 
-	public DonationController(DonationService donationService) {
+	public DonationController(
+		DonationService donationService,
+		CommentService commentService
+	) {
 		this.donationService = donationService;
+		this.commentService = commentService;
 	}
 
 	@PostMapping
@@ -54,4 +61,13 @@ public class DonationController {
 		donationService.removeDonation(id);
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
+
+	@PostMapping("/{id}/comments")
+	public ResponseEntity<ApiResponse<Long>> registerComment(
+		@PathVariable Long id,
+		@Valid @RequestBody CommentRequest request
+	) {
+		return ResponseEntity.ok(ApiResponse.of(commentService.registerComment(id, request)));
+	}
+
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
@@ -109,6 +109,10 @@ public class Donation extends BaseEntity {
 		this.tags.add(buildHaveTag(tag));
 	}
 
+	public void addComment(DonationComment donationComment) {
+		this.comments.add(donationComment);
+	}
+
 	private DonationHaveTag buildHaveTag(ThemeTag tag) {
 		return DonationHaveTag.registerDonationTag(this, tag);
 

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
@@ -1,7 +1,7 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
-import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import com.prgrms.needit.common.enums.DonationCategory;
 import com.prgrms.needit.common.enums.DonationQuality;
 import com.prgrms.needit.common.enums.DonationStatus;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationComment.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationComment.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.center.entity.Center;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationHaveTag.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationHaveTag.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationImage.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationImage.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/CommentRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/CommentRepository.java
@@ -1,8 +1,10 @@
 package com.prgrms.needit.domain.board.donation.repository;
 
 import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<DonationComment, Long> {
 
+	Optional<DonationComment> findByIdAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/CommentRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.needit.domain.board.donation.repository;
+
+import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<DonationComment, Long> {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/ThemeTagRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/ThemeTagRepository.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.repository;
 
-import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ThemeTagRepository extends JpaRepository<ThemeTag, Long> {

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/CommentService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/CommentService.java
@@ -1,6 +1,10 @@
 package com.prgrms.needit.domain.board.donation.service;
 
 import com.prgrms.needit.common.domain.dto.CommentRequest;
+import com.prgrms.needit.common.error.ErrorCode;
+import com.prgrms.needit.common.error.exception.NotFoundResourceException;
+import com.prgrms.needit.common.error.exception.NotMatchCommentException;
+import com.prgrms.needit.common.error.exception.NotMatchWriterException;
 import com.prgrms.needit.domain.board.donation.entity.Donation;
 import com.prgrms.needit.domain.board.donation.entity.DonationComment;
 import com.prgrms.needit.domain.board.donation.repository.CommentRepository;
@@ -26,7 +30,6 @@ public class CommentService {
 		this.commentRepository = commentRepository;
 	}
 
-
 	@Transactional
 	public Long registerComment(Long id, CommentRequest request) {
 		Center center = centerRepository.findById(1L)
@@ -39,5 +42,35 @@ public class CommentService {
 		return commentRepository.save(donationComment)
 								.getId();
 	}
-	
+
+	@Transactional
+	public void removeComment(Long donationId, Long commentId) {
+		Center center = centerRepository.findById(1L)
+										.get();
+		Donation donation = donationService.findActiveDonation(donationId);
+		DonationComment comment = findActiveComment(commentId);
+
+		if (!comment.getDonation()
+					.equals(donation)) {
+			throw new NotMatchCommentException(ErrorCode.NOT_MATCH_COMMENT);
+		}
+		checkWriter(center, comment);
+
+		comment.deleteEntity();
+	}
+
+	@Transactional(readOnly = true)
+	public DonationComment findActiveComment(Long id) {
+		return commentRepository
+			.findByIdAndIsDeletedFalse(id)
+			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_WISH_COMMENT));
+	}
+
+	private void checkWriter(Center center, DonationComment comment) {
+		if (!comment.getCenter()
+					.equals(center)) {
+			throw new NotMatchWriterException(ErrorCode.NOT_MATCH_WRITER);
+		}
+	}
+
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/CommentService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/CommentService.java
@@ -1,0 +1,43 @@
+package com.prgrms.needit.domain.board.donation.service;
+
+import com.prgrms.needit.common.domain.dto.CommentRequest;
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import com.prgrms.needit.domain.board.donation.repository.CommentRepository;
+import com.prgrms.needit.domain.center.entity.Center;
+import com.prgrms.needit.domain.center.repository.CenterRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CommentService {
+
+	private final CenterRepository centerRepository;
+	private final DonationService donationService;
+	private final CommentRepository commentRepository;
+
+	public CommentService(
+		CenterRepository centerRepository,
+		DonationService donationService,
+		CommentRepository commentRepository
+	) {
+		this.centerRepository = centerRepository;
+		this.donationService = donationService;
+		this.commentRepository = commentRepository;
+	}
+
+
+	@Transactional
+	public Long registerComment(Long id, CommentRequest request) {
+		Center center = centerRepository.findById(1L)
+										.get();
+		Donation donation = donationService.findActiveDonation(id);
+		DonationComment donationComment = request.toEntity(center, donation);
+
+		donation.addComment(donationComment);
+
+		return commentRepository.save(donationComment)
+								.getId();
+	}
+	
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.service;
 
-import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import com.prgrms.needit.common.enums.DonationStatus;
 import com.prgrms.needit.common.error.ErrorCode;
 import com.prgrms.needit.common.error.exception.NotFoundResourceException;

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWish.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWish.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.DonationCategory;
 import com.prgrms.needit.common.enums.DonationStatus;
 import com.prgrms.needit.domain.center.entity.Center;

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishComment.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishComment.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.member.entity.Member;
 import javax.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishHaveTag.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishHaveTag.java
@@ -1,8 +1,7 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
-import com.prgrms.needit.common.domain.ThemeTag;
-import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -10,7 +9,6 @@ import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 
 @Getter
 @Entity

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishImage.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishImage.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/src/main/java/com/prgrms/needit/domain/center/entity/Center.java
+++ b/src/main/java/com/prgrms/needit/domain/center/entity/Center.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.center.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/center/repository/CenterRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/center/repository/CenterRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.needit.domain.center.repository;
+
+import com.prgrms.needit.domain.center.entity.Center;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CenterRepository extends JpaRepository<Center, Long> {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/member/entity/FavoriteCenter.java
+++ b/src/main/java/com/prgrms/needit/domain/member/entity/FavoriteCenter.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.member.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.center.entity.Center;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/src/main/java/com/prgrms/needit/domain/member/entity/Member.java
+++ b/src/main/java/com/prgrms/needit/domain/member/entity/Member.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.member.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/message/entity/MessageContract.java
+++ b/src/main/java/com/prgrms/needit/domain/message/entity/MessageContract.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.message.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import java.time.LocalDateTime;
 import javax.persistence.Column;

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/CommentControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/CommentControllerTest.java
@@ -1,0 +1,65 @@
+package com.prgrms.needit.domain.board.donation.controller;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.prgrms.needit.common.BaseIntegrationTest;
+import com.prgrms.needit.common.domain.dto.CommentRequest;
+import com.prgrms.needit.common.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class CommentControllerTest extends BaseIntegrationTest {
+
+	private static final Long DONATION_ID = 1L;
+	private static final Long COMMENT_ID = 1L;
+	private static final String COMMENT = "기부희망";
+	private static final Long NO_ID = 0L;
+
+	@DisplayName("센터의 기부희망댓글 등록")
+	@Test
+	void registerComment() throws Exception {
+		CommentRequest registerRequest = new CommentRequest(COMMENT);
+
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .post("/donation/{id}/comments", DONATION_ID)
+						 .content(objectMapper.writeValueAsString(registerRequest))
+						 .contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("success"))
+			.andExpect(jsonPath("$.data").exists());
+	}
+
+	@DisplayName("센터의 기부희망댓글 삭제")
+	@Test
+	void removeComment() throws Exception {
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .delete(
+							 "/donation/{donationId}/comments/{commentId}",
+							 DONATION_ID, COMMENT_ID
+						 )
+			)
+			.andExpect(status().isNoContent());
+	}
+
+	@DisplayName("기부희망댓글이 존재하지 않을 경우 예외처리")
+	@Test
+	void removeDonationByNoDonation() throws Exception {
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .delete(
+							 "/donation/{donationId}/comments/{commentId}",
+							 DONATION_ID, NO_ID
+						 )
+			)
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message")
+						   .value(ErrorCode.NOT_FOUND_WISH_COMMENT.getMessage()))
+			.andExpect(jsonPath("$.code")
+						   .value(ErrorCode.NOT_FOUND_WISH_COMMENT.getCode()));
+	}
+
+}

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
@@ -10,11 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-@SpringBootTest
 class DonationControllerTest extends BaseIntegrationTest {
 
 	private static final Long ID = 1L;
@@ -24,7 +22,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 	private static final String QUALITY = "상";
 	private static final List<Long> TAGS = new ArrayList<>(List.of(1L, 2L, 3L));
 	private static final String UPDATE_STATUS = "기부 완료";
-	private static final Long NO_ID = 2L;
+	private static final Long NO_ID = 0L;
 
 	@DisplayName("회원의 기부글 등록")
 	@Test


### PR DESCRIPTION
## 💻 작업내역

 - 기부글 조회 후 해당 기부를 원하는 센터들이 **기부희망댓글** 기능을 통해 기부를 요청할 수 있다.
 - 기부희망댓글 등록, 삭제 API 구현 → 디폴트로 정해진 내용으로 댓글이 등록되기때문에 따로 수정 기능은 없다.
 - 기부희망댓글 등록, 삭제 테스트 