### PR TITLE
✨ feat : 기부글 관리(등록/수정/삭제), 기부희망댓글 관리(등록/삭제)

### DIFF
--- a/src/main/java/com/prgrms/needit/common/domain/BaseEntity.java
+++ b/src/main/java/com/prgrms/needit/common/domain/BaseEntity.java
@@ -33,4 +33,7 @@ public abstract class BaseEntity {
 	@Column(name = "is_deleted", nullable = false, columnDefinition = "TINYINT default 0")
 	private boolean isDeleted;
 
+	public void deleteEntity(){
+		this.isDeleted = true;
+	}
 }

--- a/src/main/java/com/prgrms/needit/common/domain/ThemeTag.java
+++ b/src/main/java/com/prgrms/needit/common/domain/ThemeTag.java
@@ -24,10 +24,6 @@ public class ThemeTag {
 	@Column(name = "name", length = 32, nullable = false, unique = true)
 	private String tagName;
 
-	public void setId(Long id) {
-		this.id = id;
-	}
-
 	private ThemeTag(String tagName) {
 		this.tagName = tagName;
 	}

--- a/src/main/java/com/prgrms/needit/common/domain/dto/CommentRequest.java
+++ b/src/main/java/com/prgrms/needit/common/domain/dto/CommentRequest.java
@@ -1,0 +1,29 @@
+package com.prgrms.needit.common.domain.dto;
+
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import com.prgrms.needit.domain.center.entity.Center;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentRequest {
+
+	@NotBlank(message = "댓글을 입력해주세요")
+	private String comment;
+
+	public CommentRequest(String comment) {
+		this.comment = comment;
+	}
+
+	public DonationComment toEntity(Center center, Donation donation) {
+		return DonationComment.builder()
+							  .comment(comment)
+							  .donation(donation)
+							  .center(center)
+							  .build();
+	}
+
+}

--- a/src/main/java/com/prgrms/needit/common/domain/entity/BaseEntity.java
+++ b/src/main/java/com/prgrms/needit/common/domain/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.prgrms.needit.common.domain;
+package com.prgrms.needit.common.domain.entity;
 
 import java.time.LocalDateTime;
 import javax.persistence.Column;

--- a/src/main/java/com/prgrms/needit/common/domain/entity/ThemeTag.java
+++ b/src/main/java/com/prgrms/needit/common/domain/entity/ThemeTag.java
@@ -1,4 +1,4 @@
-package com.prgrms.needit.common.domain;
+package com.prgrms.needit.common.domain.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/common/enums/DonationCategory.java
+++ b/src/main/java/com/prgrms/needit/common/enums/DonationCategory.java
@@ -1,6 +1,29 @@
 package com.prgrms.needit.common.enums;
 
+import com.prgrms.needit.common.error.ErrorCode;
+import com.prgrms.needit.common.error.exception.InvalidArgumentException;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
 public enum DonationCategory {
-	GOODS,
-	ACTIVITY
+	GOODS("물품"),
+	TALENT("재능");
+
+	public final String type;
+
+	DonationCategory(String type) {
+		this.type = type;
+	}
+
+	public static DonationCategory of(String category) {
+		return Arrays.stream(DonationCategory.values())
+					 .filter(
+						 donationCategory -> donationCategory.type.equalsIgnoreCase(category)
+					 )
+					 .findFirst()
+					 .orElseThrow(
+						 () -> new InvalidArgumentException(ErrorCode.INVALID_CATEGORY_VALUE)
+					 );
+	}
 }

--- a/src/main/java/com/prgrms/needit/common/enums/DonationQuality.java
+++ b/src/main/java/com/prgrms/needit/common/enums/DonationQuality.java
@@ -1,7 +1,30 @@
 package com.prgrms.needit.common.enums;
 
+import com.prgrms.needit.common.error.ErrorCode;
+import com.prgrms.needit.common.error.exception.InvalidArgumentException;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
 public enum DonationQuality {
-	HIGH,
-	MEDIUM,
-	LOW
+	HIGH("상"),
+	MEDIUM("중"),
+	LOW("하");
+
+	public final String type;
+
+	DonationQuality(String type) {
+		this.type = type;
+	}
+
+	public static DonationQuality of(String quality) {
+		return Arrays.stream(DonationQuality.values())
+					 .filter(
+						 donationQuality -> donationQuality.type.equalsIgnoreCase(quality)
+					 )
+					 .findFirst()
+					 .orElseThrow(
+						 () -> new InvalidArgumentException(ErrorCode.INVALID_QUALITY_VALUE)
+					 );
+	}
 }

--- a/src/main/java/com/prgrms/needit/common/enums/DonationStatus.java
+++ b/src/main/java/com/prgrms/needit/common/enums/DonationStatus.java
@@ -1,8 +1,6 @@
 package com.prgrms.needit.common.enums;
 
 public enum DonationStatus {
-	REQUESTED,
-	ACCEPTED,
-	REFUSED,
-	CANCELLED
+	DONATING,
+	DONE,
 }

--- a/src/main/java/com/prgrms/needit/common/enums/DonationStatus.java
+++ b/src/main/java/com/prgrms/needit/common/enums/DonationStatus.java
@@ -1,6 +1,27 @@
 package com.prgrms.needit.common.enums;
 
+import com.prgrms.needit.common.error.ErrorCode;
+import com.prgrms.needit.common.error.exception.InvalidArgumentException;
+import java.util.Arrays;
+
 public enum DonationStatus {
-	DONATING,
-	DONE,
+	DONATING("기부 중"),
+	DONE("기부 완료");
+
+	public final String type;
+
+	DonationStatus(String type) {
+		this.type = type;
+	}
+
+	public static DonationStatus of(String status) {
+		return Arrays.stream(DonationStatus.values())
+					 .filter(
+						 donationStatus -> donationStatus.type.equalsIgnoreCase(status)
+					 )
+					 .findFirst()
+					 .orElseThrow(
+						 () -> new InvalidArgumentException(ErrorCode.INVALID_STATUS_VALUE)
+					 );
+	}
 }

--- a/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
+++ b/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
@@ -10,9 +10,8 @@ public enum ErrorCode {
 
 	NOT_FOUND_DONATION(404, "D001", "존재하지 않는 기부글입니다."),
 	INVALID_CATEGORY_VALUE(400, "D002", "잘못된 카테고리 타입입니다."),
-	INVALID_QUALITY_VALUE(400, "D003", "잘못된 거래 상태 타입입니다."),
-	INVALID_STATUS_VALUE(400, "D004", "잘못된 거래 상태 타입입니다.")
-	;
+	INVALID_QUALITY_VALUE(400, "D003", "잘못된 품질상태 타입입니다."),
+	INVALID_STATUS_VALUE(400, "D004", "잘못된 거래상태 타입입니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
+++ b/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(500, "C001", "정의되지 않은 에러가 발생했습니다."),
 	INVALID_INPUT_VALUE(400, "C002", "올바른 입력 형식이 아닙니다."),
-	NOT_MATCH_WRITER(400, "D003", "게시글의 작성자가 아닙니다."),
+	NOT_MATCH_WRITER(400, "C003", "게시글의 작성자가 아닙니다."),
 	NOT_MATCH_COMMENT(400, "C004", "게시글의 댓글이 아닙니다."),
 
 	NOT_FOUND_DONATION(404, "D001", "존재하지 않는 기부글입니다."),

--- a/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
+++ b/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
@@ -6,10 +6,11 @@ import lombok.Getter;
 public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(500, "C001", "정의되지 않은 에러가 발생했습니다."),
 	INVALID_INPUT_VALUE(400, "C002", "올바른 입력 형식이 아닙니다."),
+	NOT_MATCH_WRITER(400, "D003", "게시글의 작성자가 아닙니다."),
 
 	INVALID_CATEGORY_VALUE(400, "D001", "잘못된 카테고리 타입입니다."),
-	INVALID_QUALITY_VALUE(400, "D001", "잘못된 거래 상태 타입입니다.")
-	;
+	INVALID_QUALITY_VALUE(400, "D001", "잘못된 거래 상태 타입입니다."),
+	NOT_FOUND_DONATION(404, "D003", "존재하지 않는 기부글입니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
+++ b/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
@@ -7,11 +7,13 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(500, "C001", "정의되지 않은 에러가 발생했습니다."),
 	INVALID_INPUT_VALUE(400, "C002", "올바른 입력 형식이 아닙니다."),
 	NOT_MATCH_WRITER(400, "D003", "게시글의 작성자가 아닙니다."),
+	NOT_MATCH_COMMENT(400, "C004", "게시글의 댓글이 아닙니다."),
 
 	NOT_FOUND_DONATION(404, "D001", "존재하지 않는 기부글입니다."),
 	INVALID_CATEGORY_VALUE(400, "D002", "잘못된 카테고리 타입입니다."),
 	INVALID_QUALITY_VALUE(400, "D003", "잘못된 품질상태 타입입니다."),
-	INVALID_STATUS_VALUE(400, "D004", "잘못된 거래상태 타입입니다.");
+	INVALID_STATUS_VALUE(400, "D004", "잘못된 거래상태 타입입니다."),
+	NOT_FOUND_WISH_COMMENT(404, "D005", "존재하지 않는 기부희망댓글입니다.");
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
+++ b/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
@@ -8,9 +8,11 @@ public enum ErrorCode {
 	INVALID_INPUT_VALUE(400, "C002", "올바른 입력 형식이 아닙니다."),
 	NOT_MATCH_WRITER(400, "D003", "게시글의 작성자가 아닙니다."),
 
-	INVALID_CATEGORY_VALUE(400, "D001", "잘못된 카테고리 타입입니다."),
-	INVALID_QUALITY_VALUE(400, "D001", "잘못된 거래 상태 타입입니다."),
-	NOT_FOUND_DONATION(404, "D003", "존재하지 않는 기부글입니다.");
+	NOT_FOUND_DONATION(404, "D001", "존재하지 않는 기부글입니다."),
+	INVALID_CATEGORY_VALUE(400, "D002", "잘못된 카테고리 타입입니다."),
+	INVALID_QUALITY_VALUE(400, "D003", "잘못된 거래 상태 타입입니다."),
+	INVALID_STATUS_VALUE(400, "D004", "잘못된 거래 상태 타입입니다.")
+	;
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
+++ b/src/main/java/com/prgrms/needit/common/error/ErrorCode.java
@@ -5,7 +5,11 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(500, "C001", "정의되지 않은 에러가 발생했습니다."),
-	INVALID_INPUT_VALUE(400, "C002", "올바른 입력 형식이 아닙니다.");
+	INVALID_INPUT_VALUE(400, "C002", "올바른 입력 형식이 아닙니다."),
+
+	INVALID_CATEGORY_VALUE(400, "D001", "잘못된 카테고리 타입입니다."),
+	INVALID_QUALITY_VALUE(400, "D001", "잘못된 거래 상태 타입입니다.")
+	;
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/prgrms/needit/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/needit/common/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.prgrms.needit.common.error;
 
 import com.prgrms.needit.common.error.exception.InvalidArgumentException;
 import com.prgrms.needit.common.error.exception.NotFoundResourceException;
+import com.prgrms.needit.common.error.exception.NotMatchCommentException;
 import com.prgrms.needit.common.error.exception.NotMatchWriterException;
 import com.prgrms.needit.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,16 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NotMatchWriterException.class)
 	public ResponseEntity<ErrorResponse> NotMatchWriterExceptionHandler(NotMatchWriterException ex) {
+		log.error("Exception : " + ex.getMessage());
+		ErrorResponse response = ErrorResponse.of(
+			ex.getErrorCode()
+		);
+
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(NotMatchCommentException.class)
+	public ResponseEntity<ErrorResponse> NotMatchCommentExceptionHandler(NotMatchCommentException ex) {
 		log.error("Exception : " + ex.getMessage());
 		ErrorResponse response = ErrorResponse.of(
 			ex.getErrorCode()

--- a/src/main/java/com/prgrms/needit/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/needit/common/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.prgrms.needit.common.error;
 
+import com.prgrms.needit.common.error.exception.InvalidArgumentException;
 import com.prgrms.needit.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,16 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+	@ExceptionHandler(InvalidArgumentException.class)
+	public ResponseEntity<ErrorResponse> InvalidArgumentExceptionHandler(InvalidArgumentException ex) {
+		log.error("Exception : " + ex.getMessage());
+		ErrorResponse response = ErrorResponse.of(
+			ex.getErrorCode()
+		);
+
+		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> globalExceptionHandler(Exception ex) {

--- a/src/main/java/com/prgrms/needit/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/needit/common/error/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.prgrms.needit.common.error;
 
 import com.prgrms.needit.common.error.exception.InvalidArgumentException;
+import com.prgrms.needit.common.error.exception.NotFoundResourceException;
+import com.prgrms.needit.common.error.exception.NotMatchWriterException;
 import com.prgrms.needit.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -20,6 +22,26 @@ public class GlobalExceptionHandler {
 		);
 
 		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	@ExceptionHandler(NotFoundResourceException.class)
+	public ResponseEntity<ErrorResponse> NotFoundResourceExceptionHandler(NotFoundResourceException ex) {
+		log.error("Exception : " + ex.getMessage());
+		ErrorResponse response = ErrorResponse.of(
+			ex.getErrorCode()
+		);
+
+		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+	}
+
+	@ExceptionHandler(NotMatchWriterException.class)
+	public ResponseEntity<ErrorResponse> NotMatchWriterExceptionHandler(NotMatchWriterException ex) {
+		log.error("Exception : " + ex.getMessage());
+		ErrorResponse response = ErrorResponse.of(
+			ex.getErrorCode()
+		);
+
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/src/main/java/com/prgrms/needit/common/error/exception/InvalidArgumentException.java
+++ b/src/main/java/com/prgrms/needit/common/error/exception/InvalidArgumentException.java
@@ -1,0 +1,16 @@
+package com.prgrms.needit.common.error.exception;
+
+import com.prgrms.needit.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidArgumentException extends RuntimeException {
+
+	private ErrorCode errorCode;
+
+	public InvalidArgumentException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+
+}
+

--- a/src/main/java/com/prgrms/needit/common/error/exception/NotFoundResourceException.java
+++ b/src/main/java/com/prgrms/needit/common/error/exception/NotFoundResourceException.java
@@ -1,0 +1,14 @@
+package com.prgrms.needit.common.error.exception;
+
+import com.prgrms.needit.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotFoundResourceException extends RuntimeException {
+
+	private ErrorCode errorCode;
+
+	public NotFoundResourceException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/prgrms/needit/common/error/exception/NotMatchCommentException.java
+++ b/src/main/java/com/prgrms/needit/common/error/exception/NotMatchCommentException.java
@@ -1,0 +1,15 @@
+package com.prgrms.needit.common.error.exception;
+
+import com.prgrms.needit.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotMatchCommentException extends RuntimeException {
+
+	private ErrorCode errorCode;
+
+	public NotMatchCommentException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+
+}

--- a/src/main/java/com/prgrms/needit/common/error/exception/NotMatchWriterException.java
+++ b/src/main/java/com/prgrms/needit/common/error/exception/NotMatchWriterException.java
@@ -1,0 +1,15 @@
+package com.prgrms.needit.common.error.exception;
+
+import com.prgrms.needit.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotMatchWriterException extends RuntimeException {
+
+	private ErrorCode errorCode;
+
+	public NotMatchWriterException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+}
+

--- a/src/main/java/com/prgrms/needit/domain/board/activity/entity/Activity.java
+++ b/src/main/java/com/prgrms/needit/domain/board/activity/entity/Activity.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.activity.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.center.entity.Center;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/board/activity/entity/ActivityComment.java
+++ b/src/main/java/com/prgrms/needit/domain/board/activity/entity/ActivityComment.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.activity.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/board/activity/entity/ActivityImage.java
+++ b/src/main/java/com/prgrms/needit/domain/board/activity/entity/ActivityImage.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.activity.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -1,0 +1,5 @@
+package com.prgrms.needit.domain.board.donation.controller;
+
+public class DonationController {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -5,7 +5,9 @@ import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import com.prgrms.needit.domain.board.donation.service.DonationService;
 import javax.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,5 +47,11 @@ public class DonationController {
 		@Valid @RequestBody DonationStatusRequest request
 	) {
 		return ResponseEntity.ok(ApiResponse.of(donationService.modifyDealStatus(id, request)));
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> removeDonation(@PathVariable Long id) {
+		donationService.removeDonation(id);
+		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -1,5 +1,29 @@
 package com.prgrms.needit.domain.board.donation.controller;
 
+import com.prgrms.needit.common.response.ApiResponse;
+import com.prgrms.needit.domain.board.donation.dto.DonationRegisterRequest;
+import com.prgrms.needit.domain.board.donation.service.DonationService;
+import javax.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/donation")
 public class DonationController {
 
+	private final DonationService donationService;
+
+	public DonationController(DonationService donationService) {
+		this.donationService = donationService;
+	}
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<Long>> registerDonation(
+		@Valid @RequestBody DonationRegisterRequest request
+	) {
+		return ResponseEntity.ok(ApiResponse.of(donationService.registerDonation(request)));
+	}
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/donation")
+@RequestMapping("/donations")
 public class DonationController {
 
 	private final DonationService donationService;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -1,11 +1,13 @@
 package com.prgrms.needit.domain.board.donation.controller;
 
 import com.prgrms.needit.common.response.ApiResponse;
-import com.prgrms.needit.domain.board.donation.dto.DonationRegisterRequest;
+import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.service.DonationService;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,8 +24,16 @@ public class DonationController {
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<Long>> registerDonation(
-		@Valid @RequestBody DonationRegisterRequest request
+		@Valid @RequestBody DonationRequest request
 	) {
 		return ResponseEntity.ok(ApiResponse.of(donationService.registerDonation(request)));
+	}
+
+	@PutMapping("/{id}")
+	public ResponseEntity<ApiResponse<Long>> modifyDonation(
+		@PathVariable Long id,
+		@Valid @RequestBody DonationRequest request
+	) {
+		return ResponseEntity.ok(ApiResponse.of(donationService.modifyDonation(id, request)));
 	}
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -70,4 +70,12 @@ public class DonationController {
 		return ResponseEntity.ok(ApiResponse.of(commentService.registerComment(id, request)));
 	}
 
+	@DeleteMapping("/{donationId}/comments/{commentId}")
+	public ResponseEntity<Void> removeComment(
+		@PathVariable Long donationId,
+		@PathVariable Long commentId
+	) {
+		commentService.removeComment(donationId, commentId);
+		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+	}
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -1,8 +1,10 @@
 package com.prgrms.needit.domain.board.donation.controller;
 
+import com.prgrms.needit.common.domain.dto.CommentRequest;
 import com.prgrms.needit.common.response.ApiResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
+import com.prgrms.needit.domain.board.donation.service.CommentService;
 import com.prgrms.needit.domain.board.donation.service.DonationService;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -21,9 +23,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class DonationController {
 
 	private final DonationService donationService;
+	private final CommentService commentService;
 
-	public DonationController(DonationService donationService) {
+	public DonationController(
+		DonationService donationService,
+		CommentService commentService
+	) {
 		this.donationService = donationService;
+		this.commentService = commentService;
 	}
 
 	@PostMapping
@@ -54,4 +61,13 @@ public class DonationController {
 		donationService.removeDonation(id);
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
+
+	@PostMapping("/{id}/comments")
+	public ResponseEntity<ApiResponse<Long>> registerComment(
+		@PathVariable Long id,
+		@Valid @RequestBody CommentRequest request
+	) {
+		return ResponseEntity.ok(ApiResponse.of(commentService.registerComment(id, request)));
+	}
+
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -2,9 +2,11 @@ package com.prgrms.needit.domain.board.donation.controller;
 
 import com.prgrms.needit.common.response.ApiResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
+import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import com.prgrms.needit.domain.board.donation.service.DonationService;
 import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -35,5 +37,13 @@ public class DonationController {
 		@Valid @RequestBody DonationRequest request
 	) {
 		return ResponseEntity.ok(ApiResponse.of(donationService.modifyDonation(id, request)));
+	}
+
+	@PatchMapping("/{id}")
+	public ResponseEntity<ApiResponse<Long>> modifyDealStatus(
+		@PathVariable Long id,
+		@Valid @RequestBody DonationStatusRequest request
+	) {
+		return ResponseEntity.ok(ApiResponse.of(donationService.modifyDealStatus(id, request)));
 	}
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationRegisterRequest.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationRegisterRequest.java
@@ -1,0 +1,41 @@
+package com.prgrms.needit.domain.board.donation.dto;
+
+import com.prgrms.needit.common.enums.DonationCategory;
+import com.prgrms.needit.common.enums.DonationQuality;
+import com.prgrms.needit.common.enums.DonationStatus;
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DonationRegisterRequest {
+
+	@NotBlank
+	private String title;
+
+	@NotBlank
+	private String content;
+
+	@NotBlank
+	private String category;
+
+	@NotBlank
+	private String quality;
+
+	private List<Long> tags = new ArrayList<>();
+
+	public Donation toEntity() {
+		return Donation.builder()
+					   .title(title)
+					   .content(content)
+					   .category(DonationCategory.of(category))
+					   .quality(DonationQuality.of(quality))
+					   .status(DonationStatus.DONATING)
+					   .build();
+	}
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationRegisterRequest.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationRegisterRequest.java
@@ -28,6 +28,21 @@ public class DonationRegisterRequest {
 
 	private List<Long> tags = new ArrayList<>();
 
+	public DonationRegisterRequest(
+		String title,
+		String content,
+		String category,
+		String quality,
+		List<Long> tags
+	) {
+		this.title = title;
+		this.content = content;
+		this.category = category;
+		this.quality = quality;
+		this.tags = tags;
+	}
+
+
 	public Donation toEntity() {
 		return Donation.builder()
 					   .title(title)

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationRequest.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class DonationRegisterRequest {
+public class DonationRequest {
 
 	@NotBlank
 	private String title;
@@ -28,7 +28,7 @@ public class DonationRegisterRequest {
 
 	private List<Long> tags = new ArrayList<>();
 
-	public DonationRegisterRequest(
+	public DonationRequest(
 		String title,
 		String content,
 		String category,
@@ -41,7 +41,6 @@ public class DonationRegisterRequest {
 		this.quality = quality;
 		this.tags = tags;
 	}
-
 
 	public Donation toEntity() {
 		return Donation.builder()

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationStatusRequest.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationStatusRequest.java
@@ -1,0 +1,17 @@
+package com.prgrms.needit.domain.board.donation.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DonationStatusRequest {
+
+	@NotBlank
+	private String status;
+
+	public DonationStatusRequest(String status) {
+		this.status = status;
+	}
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
@@ -5,6 +5,7 @@ import com.prgrms.needit.common.domain.ThemeTag;
 import com.prgrms.needit.common.enums.DonationCategory;
 import com.prgrms.needit.common.enums.DonationQuality;
 import com.prgrms.needit.common.enums.DonationStatus;
+import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.member.entity.Member;
 import java.util.ArrayList;
 import java.util.List;
@@ -80,22 +81,23 @@ public class Donation extends BaseEntity {
 	}
 
 	public void changeInfo(
-		String title,
-		String content,
-		DonationCategory category,
-		DonationQuality quality
+		DonationRequest request
 	) {
-		validateInfo(title, content, category, quality);
+		validateInfo(
+			request.getTitle(),
+			request.getContent(),
+			DonationCategory.of(request.getCategory()),
+			DonationQuality.of(request.getQuality())
+		);
 
-		this.title = title;
-		this.content = content;
-		this.category = category;
-		this.quality = quality;
+		this.title = request.getTitle();
+		this.content = request.getContent();
+		this.category = DonationCategory.of(request.getCategory());
+		this.quality = DonationQuality.of(request.getQuality());
 	}
 
 	public void changeStatus(DonationStatus status) {
 		validateStatus(status);
-
 		this.status = status;
 	}
 

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
@@ -109,6 +109,10 @@ public class Donation extends BaseEntity {
 		this.tags.add(buildHaveTag(tag));
 	}
 
+	public void addComment(DonationComment donationComment) {
+		this.comments.add(donationComment);
+	}
+
 	private DonationHaveTag buildHaveTag(ThemeTag tag) {
 		return DonationHaveTag.registerDonationTag(this, tag);
 

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
@@ -1,11 +1,10 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
 import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.ThemeTag;
 import com.prgrms.needit.common.enums.DonationCategory;
 import com.prgrms.needit.common.enums.DonationQuality;
 import com.prgrms.needit.common.enums.DonationStatus;
-import com.prgrms.needit.domain.board.wish.entity.DonationWishComment;
-import com.prgrms.needit.domain.board.wish.entity.DonationWishHaveTag;
 import com.prgrms.needit.domain.member.entity.Member;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,10 +54,10 @@ public class Donation extends BaseEntity {
 	private Member member;
 
 	@OneToMany(mappedBy = "donation", cascade = CascadeType.ALL)
-	private final List<DonationHaveTag> tags = new ArrayList<>();
+	private List<DonationHaveTag> tags = new ArrayList<>();
 
 	@OneToMany(mappedBy = "donation", cascade = CascadeType.ALL)
-	private final List<DonationComment> comments = new ArrayList<>();
+	private List<DonationComment> comments = new ArrayList<>();
 
 	@Builder
 	private Donation(
@@ -80,22 +79,6 @@ public class Donation extends BaseEntity {
 		this.member = member;
 	}
 
-	private void validateInfo(
-		String title,
-		String content,
-		DonationCategory category,
-		DonationQuality quality
-	) {
-		Assert.hasText(title, "Updated title cannot be null or empty.");
-		Assert.hasText(content, "Updated content cannot be null or empty.");
-		Assert.notNull(category, "Updated category cannot be null or empty.");
-		Assert.notNull(quality, "Updated quality cannot be null or empty.");
-	}
-
-	private void validateStatus(DonationStatus status) {
-		Assert.notNull(status, "Donation status cannot be null or empty.");
-	}
-
 	public void changeInfo(
 		String title,
 		String content,
@@ -114,6 +97,35 @@ public class Donation extends BaseEntity {
 		validateStatus(status);
 
 		this.status = status;
+	}
+
+	public void addMember(Member member) {
+		this.member = member;
+	}
+
+	public void addTag(ThemeTag tag) {
+		this.tags.add(buildHaveTag(tag));
+	}
+
+	private DonationHaveTag buildHaveTag(ThemeTag tag) {
+		return DonationHaveTag.registerDonationTag(this, tag);
+
+	}
+
+	private void validateInfo(
+		String title,
+		String content,
+		DonationCategory category,
+		DonationQuality quality
+	) {
+		Assert.hasText(title, "Updated title cannot be null or empty.");
+		Assert.hasText(content, "Updated content cannot be null or empty.");
+		Assert.notNull(category, "Updated category cannot be null or empty.");
+		Assert.notNull(quality, "Updated quality cannot be null or empty.");
+	}
+
+	private void validateStatus(DonationStatus status) {
+		Assert.notNull(status, "Donation status cannot be null or empty.");
 	}
 
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
@@ -14,6 +14,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
@@ -50,7 +51,7 @@ public class Donation extends BaseEntity {
 	@Column(name = "status", nullable = false)
 	private DonationStatus status;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", referencedColumnName = "id")
 	private Member member;
 
@@ -115,7 +116,6 @@ public class Donation extends BaseEntity {
 
 	private DonationHaveTag buildHaveTag(ThemeTag tag) {
 		return DonationHaveTag.registerDonationTag(this, tag);
-
 	}
 
 	private void validateInfo(

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/Donation.java
@@ -1,7 +1,7 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
-import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import com.prgrms.needit.common.enums.DonationCategory;
 import com.prgrms.needit.common.enums.DonationQuality;
 import com.prgrms.needit.common.enums.DonationStatus;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationComment.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationComment.java
@@ -4,11 +4,11 @@ import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.center.entity.Center;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.*;
-import org.springframework.util.Assert;
 
 @Getter
 @Entity
@@ -19,18 +19,13 @@ public class DonationComment extends BaseEntity {
 	@Column(name = "comment", length = 512, nullable = false)
 	private String comment;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "donation_id", referencedColumnName = "id")
 	private Donation donation;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "center_id", referencedColumnName = "id")
 	private Center center;
-
-	public void changeComment(String comment) {
-		validateInfo(comment, donation, center);
-		this.comment = comment;
-	}
 
 	@Builder
 	private DonationComment(
@@ -38,16 +33,9 @@ public class DonationComment extends BaseEntity {
 		Donation donation,
 		Center center
 	) {
-		validateInfo(comment, donation, center);
 		this.comment = comment;
 		this.donation = donation;
 		this.center = center;
-	}
-
-	private static void validateInfo(String comment, Donation donation, Center center) {
-		Assert.hasText(comment, "Comment cannot be null or empty.");
-		Assert.notNull(donation, "Donation cannot be null.");
-		Assert.notNull(center, "Center cannot be null.");
 	}
 
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationComment.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationComment.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.center.entity.Center;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationHaveTag.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationHaveTag.java
@@ -3,6 +3,7 @@ package com.prgrms.needit.domain.board.donation.entity;
 import com.prgrms.needit.common.domain.entity.ThemeTag;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -24,11 +25,11 @@ public class DonationHaveTag {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "donation_id", referencedColumnName = "id")
 	private Donation donation;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "tag_id", referencedColumnName = "id")
 	private ThemeTag themeTag;
 

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationHaveTag.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationHaveTag.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationHaveTag.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationHaveTag.java
@@ -1,20 +1,28 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
 import com.prgrms.needit.common.domain.ThemeTag;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 
 @Getter
-@NoArgsConstructor
 @Entity
 @Table(name = "donation_have_tag")
-public class DonationHaveTag extends BaseEntity {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DonationHaveTag {
+
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
 	@ManyToOne
 	@JoinColumn(name = "donation_id", referencedColumnName = "id")
@@ -24,7 +32,7 @@ public class DonationHaveTag extends BaseEntity {
 	@JoinColumn(name = "tag_id", referencedColumnName = "id")
 	private ThemeTag themeTag;
 
-	public DonationHaveTag(
+	private DonationHaveTag(
 		Donation donation,
 		ThemeTag themeTag
 	) {
@@ -34,8 +42,8 @@ public class DonationHaveTag extends BaseEntity {
 
 	public static DonationHaveTag registerDonationTag(
 		Donation donation,
-		ThemeTag themeTag) {
-
+		ThemeTag themeTag
+	) {
 		return new DonationHaveTag(donation, themeTag);
 	}
 

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationImage.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationImage.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationImage.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/entity/DonationImage.java
@@ -3,32 +3,37 @@ package com.prgrms.needit.domain.board.donation.entity;
 import com.prgrms.needit.common.domain.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 
 @Getter
-@Table(name = "donation_image")
 @Entity
-@NoArgsConstructor
+@Table(name = "donation_image")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DonationImage extends BaseEntity {
-
-	@ManyToOne
-	@JoinColumn(name = "donation_id", referencedColumnName = "id")
-	private Donation donation;
 
 	@Column(name = "url", length = 512, nullable = false)
 	private String url;
 
-	@Builder
-	public DonationImage(Donation donation, String url) {
-		Assert.notNull(donation, "Donation cannot be null.");
-		Assert.hasText(url, "Image url cannot be null or blank.");
-		this.donation = donation;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "donation_id", referencedColumnName = "id")
+	private Donation donation;
+
+	private DonationImage(String url, Donation donation) {
 		this.url = url;
+		this.donation = donation;
 	}
+
+	public static DonationImage registerImage(
+		String url,
+		Donation donation
+	) {
+		return new DonationImage(url, donation);
+	}
+
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/CommentRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/CommentRepository.java
@@ -1,8 +1,10 @@
 package com.prgrms.needit.domain.board.donation.repository;
 
 import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<DonationComment, Long> {
 
+	Optional<DonationComment> findByIdAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/CommentRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.needit.domain.board.donation.repository;
+
+import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<DonationComment, Long> {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.needit.domain.board.donation.repository;
+
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DonationRepository extends JpaRepository<Donation, Long> {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationRepository.java
@@ -1,8 +1,10 @@
 package com.prgrms.needit.domain.board.donation.repository;
 
 import com.prgrms.needit.domain.board.donation.entity.Donation;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DonationRepository extends JpaRepository<Donation, Long> {
 
+	Optional<Donation> findByIdAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationTagRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationTagRepository.java
@@ -1,0 +1,10 @@
+package com.prgrms.needit.domain.board.donation.repository;
+
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.prgrms.needit.domain.board.donation.entity.DonationHaveTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DonationTagRepository extends JpaRepository<DonationHaveTag, Long> {
+
+	void deleteAllByDonation(Donation donation);
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/ThemeTagRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/ThemeTagRepository.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.repository;
 
-import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ThemeTagRepository extends JpaRepository<ThemeTag, Long> {

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/ThemeTagRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/ThemeTagRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.needit.domain.board.donation.repository;
+
+import com.prgrms.needit.common.domain.ThemeTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ThemeTagRepository extends JpaRepository<ThemeTag, Long> {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/CommentService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/CommentService.java
@@ -1,6 +1,10 @@
 package com.prgrms.needit.domain.board.donation.service;
 
 import com.prgrms.needit.common.domain.dto.CommentRequest;
+import com.prgrms.needit.common.error.ErrorCode;
+import com.prgrms.needit.common.error.exception.NotFoundResourceException;
+import com.prgrms.needit.common.error.exception.NotMatchCommentException;
+import com.prgrms.needit.common.error.exception.NotMatchWriterException;
 import com.prgrms.needit.domain.board.donation.entity.Donation;
 import com.prgrms.needit.domain.board.donation.entity.DonationComment;
 import com.prgrms.needit.domain.board.donation.repository.CommentRepository;
@@ -26,7 +30,6 @@ public class CommentService {
 		this.commentRepository = commentRepository;
 	}
 
-
 	@Transactional
 	public Long registerComment(Long id, CommentRequest request) {
 		Center center = centerRepository.findById(1L)
@@ -39,5 +42,35 @@ public class CommentService {
 		return commentRepository.save(donationComment)
 								.getId();
 	}
-	
+
+	@Transactional
+	public void removeComment(Long donationId, Long commentId) {
+		Center center = centerRepository.findById(1L)
+										.get();
+		Donation donation = donationService.findActiveDonation(donationId);
+		DonationComment comment = findActiveComment(commentId);
+
+		if (!comment.getDonation()
+					.equals(donation)) {
+			throw new NotMatchCommentException(ErrorCode.NOT_MATCH_COMMENT);
+		}
+		checkWriter(center, comment);
+
+		comment.deleteEntity();
+	}
+
+	@Transactional(readOnly = true)
+	public DonationComment findActiveComment(Long id) {
+		return commentRepository
+			.findByIdAndIsDeletedFalse(id)
+			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_WISH_COMMENT));
+	}
+
+	private void checkWriter(Center center, DonationComment comment) {
+		if (!comment.getCenter()
+					.equals(center)) {
+			throw new NotMatchWriterException(ErrorCode.NOT_MATCH_WRITER);
+		}
+	}
+
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/CommentService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/CommentService.java
@@ -1,0 +1,43 @@
+package com.prgrms.needit.domain.board.donation.service;
+
+import com.prgrms.needit.common.domain.dto.CommentRequest;
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import com.prgrms.needit.domain.board.donation.repository.CommentRepository;
+import com.prgrms.needit.domain.center.entity.Center;
+import com.prgrms.needit.domain.center.repository.CenterRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CommentService {
+
+	private final CenterRepository centerRepository;
+	private final DonationService donationService;
+	private final CommentRepository commentRepository;
+
+	public CommentService(
+		CenterRepository centerRepository,
+		DonationService donationService,
+		CommentRepository commentRepository
+	) {
+		this.centerRepository = centerRepository;
+		this.donationService = donationService;
+		this.commentRepository = commentRepository;
+	}
+
+
+	@Transactional
+	public Long registerComment(Long id, CommentRequest request) {
+		Center center = centerRepository.findById(1L)
+										.get();
+		Donation donation = donationService.findActiveDonation(id);
+		DonationComment donationComment = request.toEntity(center, donation);
+
+		donation.addComment(donationComment);
+
+		return commentRepository.save(donationComment)
+								.getId();
+	}
+	
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.donation.service;
 
-import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import com.prgrms.needit.common.enums.DonationStatus;
 import com.prgrms.needit.common.error.ErrorCode;
 import com.prgrms.needit.common.error.exception.NotFoundResourceException;

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -1,5 +1,48 @@
 package com.prgrms.needit.domain.board.donation.service;
 
+import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.domain.board.donation.dto.DonationRegisterRequest;
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.prgrms.needit.domain.board.donation.repository.DonationRepository;
+import com.prgrms.needit.domain.board.donation.repository.ThemeTagRepository;
+import com.prgrms.needit.domain.member.entity.Member;
+import com.prgrms.needit.domain.member.repository.MemberRepository;
+import javax.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Service
 public class DonationService {
 
+	private final MemberRepository memberRepository;
+	private final DonationRepository donationRepository;
+	private final ThemeTagRepository themeTagRepository;
+
+	public DonationService(
+		MemberRepository memberRepository,
+		DonationRepository donationRepository,
+		ThemeTagRepository themeTagRepository
+	) {
+		this.memberRepository = memberRepository;
+		this.donationRepository = donationRepository;
+		this.themeTagRepository = themeTagRepository;
+	}
+
+	@Transactional
+	public Long registerDonation(DonationRegisterRequest request) {
+		Member member = memberRepository.findById(1L)
+										.get();
+
+		Donation donation = request.toEntity();
+		donation.addMember(member);
+
+		for (Long tagId : request.getTags()) {
+			ThemeTag themeTag = themeTagRepository.findById(tagId)
+												  .get();
+			donation.addTag(themeTag);
+		}
+
+		return donationRepository
+			.save(donation)
+			.getId();
+	}
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -1,10 +1,12 @@
 package com.prgrms.needit.domain.board.donation.service;
 
 import com.prgrms.needit.common.domain.ThemeTag;
+import com.prgrms.needit.common.enums.DonationStatus;
 import com.prgrms.needit.common.error.ErrorCode;
 import com.prgrms.needit.common.error.exception.NotFoundResourceException;
 import com.prgrms.needit.common.error.exception.NotMatchWriterException;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
+import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import com.prgrms.needit.domain.board.donation.entity.Donation;
 import com.prgrms.needit.domain.board.donation.repository.DonationRepository;
 import com.prgrms.needit.domain.board.donation.repository.DonationTagRepository;
@@ -62,6 +64,21 @@ public class DonationService {
 		donation.changeInfo(request);
 		donationTagRepository.deleteAllByDonation(donation);
 		registerTag(request, donation);
+
+		return donation.getId();
+	}
+
+	@Transactional
+	public Long modifyDealStatus(Long id, DonationStatusRequest request) {
+		Member member = memberRepository.findById(1L)
+										.get();
+
+		Donation donation = findActiveDonation(id);
+		if (!donation.getMember().equals(member)) {
+			throw new NotMatchWriterException(ErrorCode.NOT_MATCH_WRITER);
+		}
+
+		donation.changeStatus(DonationStatus.of(request.getStatus()));
 
 		return donation.getId();
 	}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -1,14 +1,18 @@
 package com.prgrms.needit.domain.board.donation.service;
 
 import com.prgrms.needit.common.domain.ThemeTag;
-import com.prgrms.needit.domain.board.donation.dto.DonationRegisterRequest;
+import com.prgrms.needit.common.error.ErrorCode;
+import com.prgrms.needit.common.error.exception.NotFoundResourceException;
+import com.prgrms.needit.common.error.exception.NotMatchWriterException;
+import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.entity.Donation;
 import com.prgrms.needit.domain.board.donation.repository.DonationRepository;
+import com.prgrms.needit.domain.board.donation.repository.DonationTagRepository;
 import com.prgrms.needit.domain.board.donation.repository.ThemeTagRepository;
 import com.prgrms.needit.domain.member.entity.Member;
 import com.prgrms.needit.domain.member.repository.MemberRepository;
-import javax.transaction.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class DonationService {
@@ -16,33 +20,65 @@ public class DonationService {
 	private final MemberRepository memberRepository;
 	private final DonationRepository donationRepository;
 	private final ThemeTagRepository themeTagRepository;
+	private final DonationTagRepository donationTagRepository;
 
 	public DonationService(
 		MemberRepository memberRepository,
 		DonationRepository donationRepository,
-		ThemeTagRepository themeTagRepository
+		ThemeTagRepository themeTagRepository,
+		DonationTagRepository donationTagRepository
 	) {
 		this.memberRepository = memberRepository;
 		this.donationRepository = donationRepository;
 		this.themeTagRepository = themeTagRepository;
+		this.donationTagRepository = donationTagRepository;
 	}
 
 	@Transactional
-	public Long registerDonation(DonationRegisterRequest request) {
+	public Long registerDonation(DonationRequest request) {
 		Member member = memberRepository.findById(1L)
 										.get();
 
 		Donation donation = request.toEntity();
 		donation.addMember(member);
 
-		for (Long tagId : request.getTags()) {
-			ThemeTag themeTag = themeTagRepository.findById(tagId)
-												  .get();
-			donation.addTag(themeTag);
-		}
+		registerTag(request, donation);
 
 		return donationRepository
 			.save(donation)
 			.getId();
 	}
+
+	@Transactional
+	public Long modifyDonation(Long id, DonationRequest request) {
+		Member member = memberRepository.findById(1L)
+										.get();
+
+		Donation donation = findActiveDonation(id);
+		if (!donation.getMember().equals(member)) {
+			throw new NotMatchWriterException(ErrorCode.NOT_MATCH_WRITER);
+		}
+
+		donation.changeInfo(request);
+		donationTagRepository.deleteAllByDonation(donation);
+		registerTag(request, donation);
+
+		return donation.getId();
+	}
+
+	@Transactional(readOnly = true)
+	public Donation findActiveDonation(Long id) {
+		return donationRepository
+			.findByIdAndIsDeletedFalse(id)
+			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_DONATION));
+	}
+
+	private void registerTag(DonationRequest request, Donation donation) {
+		for (Long tagId : request.getTags()) {
+			ThemeTag themeTag = themeTagRepository.findById(tagId)
+												  .get();
+			donation.addTag(themeTag);
+		}
+	}
 }
+

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -57,9 +57,7 @@ public class DonationService {
 										.get();
 
 		Donation donation = findActiveDonation(id);
-		if (!donation.getMember().equals(member)) {
-			throw new NotMatchWriterException(ErrorCode.NOT_MATCH_WRITER);
-		}
+		checkWriter(member, donation);
 
 		donation.changeInfo(request);
 		donationTagRepository.deleteAllByDonation(donation);
@@ -74,13 +72,22 @@ public class DonationService {
 										.get();
 
 		Donation donation = findActiveDonation(id);
-		if (!donation.getMember().equals(member)) {
-			throw new NotMatchWriterException(ErrorCode.NOT_MATCH_WRITER);
-		}
+		checkWriter(member, donation);
 
 		donation.changeStatus(DonationStatus.of(request.getStatus()));
 
 		return donation.getId();
+	}
+
+	@Transactional
+	public void removeDonation(Long id) {
+		Member member = memberRepository.findById(1L)
+										.get();
+
+		Donation donation = findActiveDonation(id);
+		checkWriter(member, donation);
+
+		donation.deleteEntity();
 	}
 
 	@Transactional(readOnly = true)
@@ -95,6 +102,13 @@ public class DonationService {
 			ThemeTag themeTag = themeTagRepository.findById(tagId)
 												  .get();
 			donation.addTag(themeTag);
+		}
+	}
+
+	private void checkWriter(Member member, Donation donation) {
+		if (!donation.getMember()
+					 .equals(member)) {
+			throw new NotMatchWriterException(ErrorCode.NOT_MATCH_WRITER);
 		}
 	}
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -1,0 +1,5 @@
+package com.prgrms.needit.domain.board.donation.service;
+
+public class DonationService {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWish.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWish.java
@@ -72,16 +72,6 @@ public class DonationWish extends BaseEntity {
 		this.center = center;
 	}
 
-	private void validateInfo(String title, String content, DonationCategory category) {
-		Assert.hasText(title, "Updated title cannot be null or blank.");
-		Assert.hasText(content, "Updated content cannot be null or blank.");
-		Assert.notNull(category, "Updated category cannot be null or blank.");
-	}
-
-	private void validateStatus(DonationStatus status) {
-		Assert.notNull(status, "Donation wish status cannot be null or blank.");
-	}
-
 	public void changeInfo(String title, String content, DonationCategory category) {
 		validateInfo(title, content, category);
 
@@ -92,13 +82,22 @@ public class DonationWish extends BaseEntity {
 
 	public void changeStatus(DonationStatus status) {
 		validateStatus(status);
-
 		this.status = status;
 	}
 
 	public void addTag(DonationWishHaveTag tag) {
 		this.getTags()
 			.add(tag);
+	}
+
+	private void validateInfo(String title, String content, DonationCategory category) {
+		Assert.hasText(title, "Updated title cannot be null or blank.");
+		Assert.hasText(content, "Updated content cannot be null or blank.");
+		Assert.notNull(category, "Updated category cannot be null or blank.");
+	}
+
+	private void validateStatus(DonationStatus status) {
+		Assert.notNull(status, "Donation wish status cannot be null or blank.");
 	}
 
 }

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWish.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWish.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.DonationCategory;
 import com.prgrms.needit.common.enums.DonationStatus;
 import com.prgrms.needit.domain.center.entity.Center;

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishComment.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishComment.java
@@ -2,11 +2,13 @@ package com.prgrms.needit.domain.board.wish.entity;
 
 import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.member.entity.Member;
-import javax.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.*;
 
 @Getter
 @Entity
@@ -17,11 +19,11 @@ public class DonationWishComment extends BaseEntity {
 	@Column(name = "comment", length = 512, nullable = false)
 	private String comment;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "donation_wish_id", referencedColumnName = "id")
 	private DonationWish donationWish;
 
-	@OneToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", referencedColumnName = "id")
 	private Member member;
 

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishComment.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishComment.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.member.entity.Member;
 import javax.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishHaveTag.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishHaveTag.java
@@ -1,8 +1,12 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.domain.entity.ThemeTag;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
@@ -13,14 +17,19 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "wish_have_tag")
-@NoArgsConstructor(access= AccessLevel.PROTECTED)
-public class DonationWishHaveTag extends BaseEntity {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DonationWishHaveTag {
 
-	@ManyToOne
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "wish_id", referencedColumnName = "id")
 	private DonationWish donationWish;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "tag_id", referencedColumnName = "id")
 	private ThemeTag themeTag;
 
@@ -34,8 +43,8 @@ public class DonationWishHaveTag extends BaseEntity {
 
 	public static DonationWishHaveTag registerWishTag(
 		DonationWish donationWish,
-		ThemeTag themeTag) {
-
+		ThemeTag themeTag
+	) {
 		return new DonationWishHaveTag(donationWish, themeTag);
 	}
 

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishHaveTag.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishHaveTag.java
@@ -1,8 +1,7 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
-import com.prgrms.needit.common.domain.ThemeTag;
-import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
+import com.prgrms.needit.common.domain.entity.ThemeTag;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -10,7 +9,6 @@ import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
 
 @Getter
 @Entity

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishImage.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishImage.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.board.wish.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishImage.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/entity/DonationWishImage.java
@@ -3,6 +3,7 @@ package com.prgrms.needit.domain.board.wish.entity;
 import com.prgrms.needit.common.domain.entity.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
@@ -19,7 +20,7 @@ public class DonationWishImage extends BaseEntity {
 	@Column(name = "url", length = 512, nullable = false)
 	private String url;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "donation_wish_id", referencedColumnName = "id")
 	private DonationWish donationWish;
 

--- a/src/main/java/com/prgrms/needit/domain/center/entity/Center.java
+++ b/src/main/java/com/prgrms/needit/domain/center/entity/Center.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.center.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/center/repository/CenterRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/center/repository/CenterRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.needit.domain.center.repository;
+
+import com.prgrms.needit.domain.center.entity.Center;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CenterRepository extends JpaRepository<Center, Long> {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/member/entity/FavoriteCenter.java
+++ b/src/main/java/com/prgrms/needit/domain/member/entity/FavoriteCenter.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.member.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.domain.center.entity.Center;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;

--- a/src/main/java/com/prgrms/needit/domain/member/entity/Member.java
+++ b/src/main/java/com/prgrms/needit/domain/member/entity/Member.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.member.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/prgrms/needit/domain/member/entity/Member.java
+++ b/src/main/java/com/prgrms/needit/domain/member/entity/Member.java
@@ -4,6 +4,8 @@ import com.prgrms.needit.common.domain.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,6 +37,7 @@ public class Member extends BaseEntity {
 	@Column(name = "image", length = 512, nullable = false)
 	private String profileImageUrl;
 
+	@Enumerated(EnumType.STRING)
 	@Column(name = "user_role")
 	private UserType userType;
 
@@ -59,11 +62,13 @@ public class Member extends BaseEntity {
 		this.userType = userType;
 	}
 
-	private void validateInfo(String email,
-							  String password,
-							  String nickname,
-							  String contact,
-							  String address) {
+	private void validateInfo(
+		String email,
+		String password,
+		String nickname,
+		String contact,
+		String address
+	) {
 		Assert.hasText(email, "Updated email cannot be null or blank.");
 		Assert.hasText(password, "Updated hashed password cannot be null or blank.");
 		Assert.hasText(nickname, "Updated center nickName cannot be null or blank.");

--- a/src/main/java/com/prgrms/needit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.prgrms.needit.domain.member.repository;
+
+import com.prgrms.needit.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/prgrms/needit/domain/message/entity/MessageContract.java
+++ b/src/main/java/com/prgrms/needit/domain/message/entity/MessageContract.java
@@ -1,6 +1,6 @@
 package com.prgrms.needit.domain.message.entity;
 
-import com.prgrms.needit.common.domain.BaseEntity;
+import com.prgrms.needit.common.domain.entity.BaseEntity;
 import com.prgrms.needit.common.enums.UserType;
 import java.time.LocalDateTime;
 import javax.persistence.Column;

--- a/src/test/java/com/prgrms/needit/common/BaseIntegrationTest.java
+++ b/src/test/java/com/prgrms/needit/common/BaseIntegrationTest.java
@@ -1,0 +1,25 @@
+package com.prgrms.needit.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.transaction.Transactional;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@Disabled
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+public class BaseIntegrationTest {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+}

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/CommentControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/CommentControllerTest.java
@@ -1,0 +1,65 @@
+package com.prgrms.needit.domain.board.donation.controller;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.prgrms.needit.common.BaseIntegrationTest;
+import com.prgrms.needit.common.domain.dto.CommentRequest;
+import com.prgrms.needit.common.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class CommentControllerTest extends BaseIntegrationTest {
+
+	private static final Long DONATION_ID = 1L;
+	private static final Long COMMENT_ID = 1L;
+	private static final String COMMENT = "기부희망";
+	private static final Long NO_ID = 0L;
+
+	@DisplayName("센터의 기부희망댓글 등록")
+	@Test
+	void registerComment() throws Exception {
+		CommentRequest registerRequest = new CommentRequest(COMMENT);
+
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .post("/donation/{id}/comments", DONATION_ID)
+						 .content(objectMapper.writeValueAsString(registerRequest))
+						 .contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("success"))
+			.andExpect(jsonPath("$.data").exists());
+	}
+
+	@DisplayName("센터의 기부희망댓글 삭제")
+	@Test
+	void removeComment() throws Exception {
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .delete(
+							 "/donation/{donationId}/comments/{commentId}",
+							 DONATION_ID, COMMENT_ID
+						 )
+			)
+			.andExpect(status().isNoContent());
+	}
+
+	@DisplayName("기부희망댓글이 존재하지 않을 경우 예외처리")
+	@Test
+	void removeDonationByNoDonation() throws Exception {
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .delete(
+							 "/donation/{donationId}/comments/{commentId}",
+							 DONATION_ID, NO_ID
+						 )
+			)
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message")
+						   .value(ErrorCode.NOT_FOUND_WISH_COMMENT.getMessage()))
+			.andExpect(jsonPath("$.code")
+						   .value(ErrorCode.NOT_FOUND_WISH_COMMENT.getCode()));
+	}
+
+}

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/CommentControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/CommentControllerTest.java
@@ -24,7 +24,7 @@ public class CommentControllerTest extends BaseIntegrationTest {
 
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
-						 .post("/donation/{id}/comments", DONATION_ID)
+						 .post("/donations/{id}/comments", DONATION_ID)
 						 .content(objectMapper.writeValueAsString(registerRequest))
 						 .contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -38,7 +38,7 @@ public class CommentControllerTest extends BaseIntegrationTest {
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
 						 .delete(
-							 "/donation/{donationId}/comments/{commentId}",
+							 "/donations/{donationId}/comments/{commentId}",
 							 DONATION_ID, COMMENT_ID
 						 )
 			)
@@ -51,7 +51,7 @@ public class CommentControllerTest extends BaseIntegrationTest {
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
 						 .delete(
-							 "/donation/{donationId}/comments/{commentId}",
+							 "/donations/{donationId}/comments/{commentId}",
 							 DONATION_ID, NO_ID
 						 )
 			)

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
@@ -33,7 +33,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
-						 .post("/donation")
+						 .post("/donations")
 						 .content(objectMapper.writeValueAsString(registerRequest))
 						 .contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -50,7 +50,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
-						 .put("/donation/{id}", ID)
+						 .put("/donations/{id}", ID)
 						 .content(objectMapper.writeValueAsString(modifyRequest))
 						 .contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -65,7 +65,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
-						 .patch("/donation/{id}", ID)
+						 .patch("/donations/{id}", ID)
 						 .content(objectMapper.writeValueAsString(modifyStatusRequest))
 						 .contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -78,7 +78,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 	void removeDonation() throws Exception {
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
-						 .delete("/donation/{id}", ID))
+						 .delete("/donations/{id}", ID))
 			.andExpect(status().isNoContent());
 	}
 
@@ -87,7 +87,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 	void removeDonationByNoDonation() throws Exception {
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
-						 .delete("/donation/{id}", NO_ID))
+						 .delete("/donations/{id}", NO_ID))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOUND_DONATION.getMessage()))
 			.andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOUND_DONATION.getCode()));

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
@@ -1,0 +1,43 @@
+package com.prgrms.needit.domain.board.donation.controller;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.prgrms.needit.common.BaseIntegrationTest;
+import com.prgrms.needit.domain.board.donation.dto.DonationRegisterRequest;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest
+class DonationControllerTest extends BaseIntegrationTest {
+
+	private static final Long ID = 1L;
+	private static final String TITLE = "기부";
+	private static final String CONTENT = "기부할래요";
+	private static final String CATEGORY = "물품";
+	private static final String QUALITY = "상";
+	private static final List<Long> TAGS = new ArrayList<>(List.of(1L, 2L, 3L));
+
+	@DisplayName("회원의 기부글 등록")
+	@Test
+	void registerDonation() throws Exception {
+		// given
+		DonationRegisterRequest registerRequest = new DonationRegisterRequest(
+			TITLE, CONTENT, CATEGORY, QUALITY, TAGS
+		);
+
+		// when then
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .post("/donation")
+						 .content(objectMapper.writeValueAsString(registerRequest))
+						 .contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("success"))
+			.andExpect(jsonPath("$.data").exists());
+	}
+}

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
@@ -3,6 +3,7 @@ package com.prgrms.needit.domain.board.donation.controller;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.prgrms.needit.common.BaseIntegrationTest;
+import com.prgrms.needit.common.error.ErrorCode;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import java.util.ArrayList;
@@ -23,16 +24,15 @@ class DonationControllerTest extends BaseIntegrationTest {
 	private static final String QUALITY = "상";
 	private static final List<Long> TAGS = new ArrayList<>(List.of(1L, 2L, 3L));
 	private static final String UPDATE_STATUS = "기부 완료";
+	private static final Long NO_ID = 2L;
 
 	@DisplayName("회원의 기부글 등록")
 	@Test
 	void registerDonation() throws Exception {
-		// given
 		DonationRequest registerRequest = new DonationRequest(
 			TITLE, CONTENT, CATEGORY, QUALITY, TAGS
 		);
 
-		// when then
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
 						 .post("/donation")
@@ -46,12 +46,10 @@ class DonationControllerTest extends BaseIntegrationTest {
 	@DisplayName("회원의 기부글 정보수정")
 	@Test
 	void modifyDonation() throws Exception {
-		// given
 		DonationRequest modifyRequest = new DonationRequest(
 			TITLE, CONTENT, CATEGORY, QUALITY, TAGS
 		);
 
-		// when then
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
 						 .put("/donation/{id}", ID)
@@ -65,10 +63,8 @@ class DonationControllerTest extends BaseIntegrationTest {
 	@DisplayName("회원의 기부글 거래상태 변경")
 	@Test
 	void modifyDealStatus() throws Exception {
-		// given
 		DonationStatusRequest modifyStatusRequest = new DonationStatusRequest(UPDATE_STATUS);
 
-		// when then
 		this.mockMvc
 			.perform(MockMvcRequestBuilders
 						 .patch("/donation/{id}", ID)
@@ -77,5 +73,25 @@ class DonationControllerTest extends BaseIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("success"))
 			.andExpect(jsonPath("$.data").value(ID));
+	}
+
+	@DisplayName("회원의 기부글 삭제")
+	@Test
+	void removeDonation() throws Exception {
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .delete("/donation/{id}", ID))
+			.andExpect(status().isNoContent());
+	}
+
+	@DisplayName("기부글이 존재하지 않을 경우 예외처리")
+	@Test
+	void removeDonationByNoDonation() throws Exception {
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .delete("/donation/{id}", NO_ID))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value(ErrorCode.NOT_FOUND_DONATION.getMessage()))
+			.andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOUND_DONATION.getCode()));
 	}
 }

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
@@ -3,7 +3,7 @@ package com.prgrms.needit.domain.board.donation.controller;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.prgrms.needit.common.BaseIntegrationTest;
-import com.prgrms.needit.domain.board.donation.dto.DonationRegisterRequest;
+import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +26,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 	@Test
 	void registerDonation() throws Exception {
 		// given
-		DonationRegisterRequest registerRequest = new DonationRegisterRequest(
+		DonationRequest registerRequest = new DonationRequest(
 			TITLE, CONTENT, CATEGORY, QUALITY, TAGS
 		);
 

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.prgrms.needit.common.BaseIntegrationTest;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
+import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +22,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 	private static final String CATEGORY = "물품";
 	private static final String QUALITY = "상";
 	private static final List<Long> TAGS = new ArrayList<>(List.of(1L, 2L, 3L));
+	private static final String UPDATE_STATUS = "기부 완료";
 
 	@DisplayName("회원의 기부글 등록")
 	@Test
@@ -39,5 +41,41 @@ class DonationControllerTest extends BaseIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("success"))
 			.andExpect(jsonPath("$.data").exists());
+	}
+
+	@DisplayName("회원의 기부글 정보수정")
+	@Test
+	void modifyDonation() throws Exception {
+		// given
+		DonationRequest modifyRequest = new DonationRequest(
+			TITLE, CONTENT, CATEGORY, QUALITY, TAGS
+		);
+
+		// when then
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .put("/donation/{id}", ID)
+						 .content(objectMapper.writeValueAsString(modifyRequest))
+						 .contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("success"))
+			.andExpect(jsonPath("$.data").value(ID));
+	}
+
+	@DisplayName("회원의 기부글 거래상태 변경")
+	@Test
+	void modifyDealStatus() throws Exception {
+		// given
+		DonationStatusRequest modifyStatusRequest = new DonationStatusRequest(UPDATE_STATUS);
+
+		// when then
+		this.mockMvc
+			.perform(MockMvcRequestBuilders
+						 .patch("/donation/{id}", ID)
+						 .content(objectMapper.writeValueAsString(modifyStatusRequest))
+						 .contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("success"))
+			.andExpect(jsonPath("$.data").value(ID));
 	}
 }

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
@@ -10,11 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-@SpringBootTest
 class DonationControllerTest extends BaseIntegrationTest {
 
 	private static final Long ID = 1L;
@@ -24,7 +22,7 @@ class DonationControllerTest extends BaseIntegrationTest {
 	private static final String QUALITY = "상";
 	private static final List<Long> TAGS = new ArrayList<>(List.of(1L, 2L, 3L));
 	private static final String UPDATE_STATUS = "기부 완료";
-	private static final Long NO_ID = 2L;
+	private static final Long NO_ID = 0L;
 
 	@DisplayName("회원의 기부글 등록")
 	@Test


### PR DESCRIPTION
## 💻 작업내역

### ♻️ refactor : 설계된 entity 부분 수정
- enum 패키지 이동
- Member, Center Entity에 userType 컬럼(변수) 추가
- DonationTag, DonationWishTag Entity 제거 후 ThemeTag 하나로 합치기
- 클래스 이름 복수형 > 단수형으로 변경

### ✨ feat : 기부글 등록 기능 구현
- 기부글 등록 API 구현 
- 기부글 등록 통합테스트 코드 작성

### ✨ feat : 기부글 수정 기능 구현
- 기부글 정보수정 API 구현
- 기부글 거래상태 변경 API 구현
- 기부글 정보수정, 거래상태 변경 통합테스트 코드 작성

### ✨ feat : 기부글 삭제 기능 구현
- 기부글 삭제 API 구현(소프트 삭제)
- 기부글 삭제 통합테스트 코드 작성

### ✨ feat : 기부희망댓글 등록, 삭제 기능 구현
> 기부글 조회 후 해당 기부를 원하는 센터들이 기부희망댓글 기능을 통해 기부를 요청할 수 있다.

- 기부희망댓글 등록, 삭제 API 구현 → 디폴트로 정해진 내용으로 댓글이 등록되기때문에 따로 수정 기능은 없다.
- 기부희망댓글 등록, 삭제 테스트

## 🔎 PR 특이 사항 

- 기본 CRUD 기능이라 변경된 파일이 별로 없을 것 같아 한번에 코드리뷰를 받으려고 했는데 변경된 파일이 많네요...😅
- 우선 위 작업내역대로 기부글 등록, 수정, 삭제 / 기부희망댓글 등록, 삭제 기능 코드리뷰 요청할게요!!
- Service 단의 `Member member = memberRepository.findById(1L).get();` 부분은 Security 적용 후 현재 로그인한 사용자의 정보를 가져오는 코드로 변경하겠습니다.