### PR TITLE
✨ feat : 기부글 단일 상세조회 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/needit/common/enums/DonationCategory.java
+++ b/src/main/java/com/prgrms/needit/common/enums/DonationCategory.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 
 @Getter
 public enum DonationCategory {
-	GOODS("물품"),
-	TALENT("재능");
+	GOODS("물품나눔"),
+	TALENT("재능기부");
 
 	public final String type;
 

--- a/src/main/java/com/prgrms/needit/common/enums/DonationQuality.java
+++ b/src/main/java/com/prgrms/needit/common/enums/DonationQuality.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 
 @Getter
 public enum DonationQuality {
-	HIGH("상"),
-	MEDIUM("중"),
-	LOW("하");
+	HIGH("좋음"),
+	MEDIUM("보통"),
+	LOW("나쁨");
 
 	public final String type;
 

--- a/src/main/java/com/prgrms/needit/common/enums/DonationStatus.java
+++ b/src/main/java/com/prgrms/needit/common/enums/DonationStatus.java
@@ -3,7 +3,9 @@ package com.prgrms.needit.common.enums;
 import com.prgrms.needit.common.error.ErrorCode;
 import com.prgrms.needit.common.error.exception.InvalidArgumentException;
 import java.util.Arrays;
+import lombok.Getter;
 
+@Getter
 public enum DonationStatus {
 	DONATING("기부 중"),
 	DONE("기부 완료");

--- a/src/main/java/com/prgrms/needit/common/enums/DonationStatus.java
+++ b/src/main/java/com/prgrms/needit/common/enums/DonationStatus.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 
 @Getter
 public enum DonationStatus {
-	DONATING("기부 중"),
-	DONE("기부 완료");
+	DONATING("기부진행"),
+	DONE("기부종료");
 
 	public final String type;
 

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -3,6 +3,7 @@ package com.prgrms.needit.domain.board.donation.controller;
 import com.prgrms.needit.common.domain.dto.CommentRequest;
 import com.prgrms.needit.common.response.ApiResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
+import com.prgrms.needit.domain.board.donation.dto.DonationResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import com.prgrms.needit.domain.board.donation.service.CommentService;
 import com.prgrms.needit.domain.board.donation.service.DonationService;
@@ -10,6 +11,7 @@ import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,6 +33,11 @@ public class DonationController {
 	) {
 		this.donationService = donationService;
 		this.commentService = commentService;
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse<DonationResponse>> getDonation(@PathVariable Long id) {
+		return ResponseEntity.ok(ApiResponse.of(donationService.getDonation(id)));
 	}
 
 	@PostMapping

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/CommentResponse.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/CommentResponse.java
@@ -1,0 +1,29 @@
+package com.prgrms.needit.domain.board.donation.dto;
+
+import com.prgrms.needit.domain.board.donation.entity.DonationComment;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class CommentResponse {
+
+	private Long id;
+	private String comment;
+	private Long centerId;
+	private String center;
+	private String centerImage;
+	private LocalDateTime createdDate;
+	private LocalDateTime updatedDate;
+
+	public CommentResponse(
+		DonationComment comment
+	) {
+		this.id = comment.getId();
+		this.comment = comment.getComment();
+		this.centerId = comment.getCenter().getId();
+		this.center = comment.getCenter().getName();
+		this.centerImage = comment.getCenter().getProfileImageUrl();
+		this.createdDate = comment.getCreatedAt();
+		this.updatedDate = comment.getUpdatedAt();
+	}
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationResponse.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationResponse.java
@@ -1,0 +1,54 @@
+package com.prgrms.needit.domain.board.donation.dto;
+
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DonationResponse {
+
+	private Long id;
+	private String title;
+	private String content;
+	private String category;
+	private String quality;
+	private String status;
+	private Long memberId;
+	private String member;
+	private String memberImg;
+	private int centerCnt;
+	private LocalDateTime createdDate;
+	private LocalDateTime updatedDate;
+	private List<String> tags = new ArrayList<>();
+	private List<CommentResponse> comments = new ArrayList<>();
+
+	public DonationResponse(
+		Donation donation
+	) {
+		this.id = donation.getId();
+		this.title = donation.getTitle();
+		this.content = donation.getContent();
+		this.category = donation.getCategory().getType();
+		this.quality = donation.getQuality().getType();
+		this.status = donation.getStatus().getType();
+		this.memberId = donation.getMember().getId();
+		this.member = donation.getMember().getNickname();
+		this.memberImg = donation.getMember().getProfileImageUrl();
+		this.createdDate = donation.getCreatedAt();
+		this.updatedDate = donation.getUpdatedAt();
+		this.centerCnt = donation.getComments().size();
+		this.tags = donation.getTags()
+							.stream()
+							.map(donationHaveTag -> donationHaveTag.getThemeTag().getTagName())
+							.collect(Collectors.toList());
+		this.comments = donation.getComments()
+								.stream()
+								.map(CommentResponse::new)
+								.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationResponse.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationResponse.java
@@ -20,7 +20,7 @@ public class DonationResponse {
 	private String status;
 	private Long memberId;
 	private String member;
-	private String memberImg;
+	private String memberImage;
 	private int centerCnt;
 	private LocalDateTime createdDate;
 	private LocalDateTime updatedDate;
@@ -38,7 +38,7 @@ public class DonationResponse {
 		this.status = donation.getStatus().getType();
 		this.memberId = donation.getMember().getId();
 		this.member = donation.getMember().getNickname();
-		this.memberImg = donation.getMember().getProfileImageUrl();
+		this.memberImage = donation.getMember().getProfileImageUrl();
 		this.createdDate = donation.getCreatedAt();
 		this.updatedDate = donation.getUpdatedAt();
 		this.centerCnt = donation.getComments().size();

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -6,6 +6,7 @@ import com.prgrms.needit.common.error.ErrorCode;
 import com.prgrms.needit.common.error.exception.NotFoundResourceException;
 import com.prgrms.needit.common.error.exception.NotMatchWriterException;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
+import com.prgrms.needit.domain.board.donation.dto.DonationResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import com.prgrms.needit.domain.board.donation.entity.Donation;
 import com.prgrms.needit.domain.board.donation.repository.DonationRepository;
@@ -34,6 +35,12 @@ public class DonationService {
 		this.donationRepository = donationRepository;
 		this.themeTagRepository = themeTagRepository;
 		this.donationTagRepository = donationTagRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public DonationResponse getDonation(Long id) {
+		return new DonationResponse(findActiveDonation(id));
+
 	}
 
 	@Transactional

--- a/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
+++ b/src/test/java/com/prgrms/needit/domain/board/donation/controller/DonationControllerTest.java
@@ -18,11 +18,38 @@ class DonationControllerTest extends BaseIntegrationTest {
 	private static final Long ID = 1L;
 	private static final String TITLE = "기부";
 	private static final String CONTENT = "기부할래요";
-	private static final String CATEGORY = "물품";
-	private static final String QUALITY = "상";
+	private static final String CATEGORY = "물품나눔";
+	private static final String QUALITY = "좋음";
 	private static final List<Long> TAGS = new ArrayList<>(List.of(1L, 2L, 3L));
-	private static final String UPDATE_STATUS = "기부 완료";
+	private static final String UPDATE_STATUS = "기부종료";
 	private static final Long NO_ID = 0L;
+
+	@DisplayName("기부글 상세 조회")
+	@Test
+	void getDonation() throws Exception {
+		this.mockMvc
+			.perform(MockMvcRequestBuilders.get("/donations/{id}", ID))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("success"))
+			.andExpect(jsonPath("$.data.id").isNumber())
+			.andExpect(jsonPath("$.data.title").isString())
+			.andExpect(jsonPath("$.data.content").isString())
+			.andExpect(jsonPath("$.data.category").isString())
+			.andExpect(jsonPath("$.data.quality").isString())
+			.andExpect(jsonPath("$.data.status").isString())
+			.andExpect(jsonPath("$.data.memberId").isNumber())
+			.andExpect(jsonPath("$.data.member").isString())
+			.andExpect(jsonPath("$.data.memberImage").isString())
+			.andExpect(jsonPath("$.data.centerCnt").isNumber())
+			.andExpect(jsonPath("$.data.tags").isArray())
+			.andExpect(jsonPath("$.data.tags[0]").isString())
+			.andExpect(jsonPath("$.data.comments").isArray())
+			.andExpect(jsonPath("$.data.comments[0].id").isNumber())
+			.andExpect(jsonPath("$.data.comments[0].comment").isString())
+			.andExpect(jsonPath("$.data.comments[0].centerId").isNumber())
+			.andExpect(jsonPath("$.data.comments[0].center").isString())
+			.andExpect(jsonPath("$.data.comments[0].centerImage").isString());
+	}
 
 	@DisplayName("회원의 기부글 등록")
 	@Test


### PR DESCRIPTION
## 💻 작업 내역

- 기부글 단일 상세조회 API 구현
- 기부글 카테고리, 품질상태, 거래상태 enum 인스턴스 값 변경
- 기부글 단일 상세조회 통합테스트 코드 작성

🔍 특이 사항

- 기부글 목록 조회 기능 구현 후 한 번에 코드리뷰 요청하겠습니닷