### PR TITLE
✨ feat : 기부글 목록 조회(동적 검색) API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '2.5.7'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'java'
 }
 
@@ -23,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.querydsl:querydsl-jpa'
 
     implementation 'io.springfox:springfox-swagger2:2.9.2'
     implementation 'io.springfox:springfox-swagger-ui:2.9.2'
@@ -30,8 +32,29 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+}
+
+// QueryDSL
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }
 
 test {

--- a/src/main/java/com/prgrms/needit/common/config/QueryDslConfig.java
+++ b/src/main/java/com/prgrms/needit/common/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.prgrms.needit.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+
+}

--- a/src/main/java/com/prgrms/needit/common/domain/dto/PageRequest.java
+++ b/src/main/java/com/prgrms/needit/common/domain/dto/PageRequest.java
@@ -1,0 +1,33 @@
+package com.prgrms.needit.common.domain.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@NoArgsConstructor
+public final class PageRequest {
+
+	private int page;
+	private int size;
+
+	public PageRequest(int page, int size) {
+		this.page = page;
+		this.size = size;
+	}
+
+	public void setPage(int page) {
+		this.page = page <= 0 ? 1 : page;
+	}
+
+	public void setSize(int size) {
+		int DEFAULT_SIZE = 10;
+		int MAX_SIZE = 50;
+		this.size = size > MAX_SIZE ? DEFAULT_SIZE : size;
+	}
+
+	public org.springframework.data.domain.PageRequest of() {
+		return org.springframework.data.domain.PageRequest.of(
+			page - 1, size, Sort.Direction.ASC, "createdAt");
+	}
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -3,25 +3,25 @@ package com.prgrms.needit.domain.board.donation.controller;
 import com.prgrms.needit.common.domain.dto.CommentRequest;
 import com.prgrms.needit.common.domain.dto.PageRequest;
 import com.prgrms.needit.common.response.ApiResponse;
+import com.prgrms.needit.domain.board.donation.dto.DonationFilterRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import com.prgrms.needit.domain.board.donation.service.CommentService;
 import com.prgrms.needit.domain.board.donation.service.DonationService;
-import java.util.List;
 import javax.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,16 +41,12 @@ public class DonationController {
 
 	@GetMapping("/search")
 	public ResponseEntity<ApiResponse<Page<DonationResponse>>> getDonations(
-		@RequestParam(required = false) String title,
-		@RequestParam(required = false) String category,
-		@RequestParam(required = false) List<Long> tags,
+		@ModelAttribute DonationFilterRequest request,
 		PageRequest pageRequest
 	) {
 		return ResponseEntity.ok(
 			ApiResponse.of(donationService.getDonations(
-				title,
-				category,
-				tags,
+				request,
 				pageRequest.of()
 			))
 		);

--- a/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/controller/DonationController.java
@@ -1,13 +1,16 @@
 package com.prgrms.needit.domain.board.donation.controller;
 
 import com.prgrms.needit.common.domain.dto.CommentRequest;
+import com.prgrms.needit.common.domain.dto.PageRequest;
 import com.prgrms.needit.common.response.ApiResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
 import com.prgrms.needit.domain.board.donation.service.CommentService;
 import com.prgrms.needit.domain.board.donation.service.DonationService;
+import java.util.List;
 import javax.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,6 +37,23 @@ public class DonationController {
 	) {
 		this.donationService = donationService;
 		this.commentService = commentService;
+	}
+
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<Page<DonationResponse>>> getDonations(
+		@RequestParam(required = false) String title,
+		@RequestParam(required = false) String category,
+		@RequestParam(required = false) List<Long> tags,
+		PageRequest pageRequest
+	) {
+		return ResponseEntity.ok(
+			ApiResponse.of(donationService.getDonations(
+				title,
+				category,
+				tags,
+				pageRequest.of()
+			))
+		);
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationFilterRequest.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationFilterRequest.java
@@ -1,0 +1,18 @@
+package com.prgrms.needit.domain.board.donation.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class DonationFilterRequest {
+
+	private String title;
+	private String category;
+	private List<Long> tags = new ArrayList<>();
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationsResponse.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationsResponse.java
@@ -1,0 +1,27 @@
+package com.prgrms.needit.domain.board.donation.dto;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DonationsResponse {
+
+	private Long id;
+	private String title;
+	private String content;
+	private String category;
+	private String quality;
+	private String status;
+	private Long memberId;
+	private String member;
+	private String memberImage;
+	private int centerCnt;
+	private LocalDateTime createdDate;
+	private LocalDateTime updatedDate;
+	private List<String> tags = new ArrayList<>();
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationCustomRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationCustomRepository.java
@@ -1,0 +1,16 @@
+package com.prgrms.needit.domain.board.donation.repository;
+
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface DonationCustomRepository {
+
+	Page<Donation> searchAllByFilter(
+		String title,
+		String category,
+		List<Long> tags,
+		Pageable pageable
+	);
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationCustomRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationCustomRepository.java
@@ -1,16 +1,14 @@
 package com.prgrms.needit.domain.board.donation.repository;
 
+import com.prgrms.needit.domain.board.donation.dto.DonationFilterRequest;
 import com.prgrms.needit.domain.board.donation.entity.Donation;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface DonationCustomRepository {
 
 	Page<Donation> searchAllByFilter(
-		String title,
-		String category,
-		List<Long> tags,
+		DonationFilterRequest request,
 		Pageable pageable
 	);
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.prgrms.needit.domain.board.donation.entity.QDonation.*;
 import static com.prgrms.needit.domain.board.donation.entity.QDonationHaveTag.*;
 
 import com.prgrms.needit.common.enums.DonationCategory;
+import com.prgrms.needit.domain.board.donation.dto.DonationFilterRequest;
 import com.prgrms.needit.domain.board.donation.entity.Donation;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -26,18 +27,16 @@ public class DonationCustomRepositoryImpl implements DonationCustomRepository {
 
 	@Override
 	public Page<Donation> searchAllByFilter(
-		String title,
-		String category,
-		List<Long> tags,
+		DonationFilterRequest request,
 		Pageable pageable
 	) {
 		QueryResults<Donation> result = jpaQueryFactory
 			.selectFrom(donation)
 			.join(donation.tags, donationHaveTag)
 			.where(
-				containTitle(title),
-				eqCategory(category),
-				eqTag(tags)
+				containTitle(request.getTitle()),
+				eqCategory(request.getCategory()),
+				eqTag(request.getTags())
 			)
 			.groupBy(donation.id)
 			.offset(pageable.getOffset())

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationCustomRepositoryImpl.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationCustomRepositoryImpl.java
@@ -1,0 +1,71 @@
+package com.prgrms.needit.domain.board.donation.repository;
+
+import static com.prgrms.needit.domain.board.donation.entity.QDonation.*;
+import static com.prgrms.needit.domain.board.donation.entity.QDonationHaveTag.*;
+
+import com.prgrms.needit.common.enums.DonationCategory;
+import com.prgrms.needit.domain.board.donation.entity.Donation;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.ObjectUtils;
+
+@Repository
+public class DonationCustomRepositoryImpl implements DonationCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public DonationCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+		this.jpaQueryFactory = jpaQueryFactory;
+	}
+
+	@Override
+	public Page<Donation> searchAllByFilter(
+		String title,
+		String category,
+		List<Long> tags,
+		Pageable pageable
+	) {
+		QueryResults<Donation> result = jpaQueryFactory
+			.selectFrom(donation)
+			.join(donation.tags, donationHaveTag)
+			.where(
+				containTitle(title),
+				eqCategory(category),
+				eqTag(tags)
+			)
+			.groupBy(donation.id)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetchResults();
+
+		return new PageImpl<>(result.getResults(), pageable, result.getTotal());
+	}
+
+	private BooleanExpression containTitle(String title) {
+		if (ObjectUtils.isEmpty(title)) {
+			return null;
+		}
+		return donation.title.contains(title);
+	}
+
+	private BooleanExpression eqCategory(String category) {
+		if (ObjectUtils.isEmpty(category)) {
+			return null;
+		}
+		return donation.category.eq(DonationCategory.of(category));
+	}
+
+	private BooleanExpression eqTag(List<Long> tags) {
+		if (ObjectUtils.isEmpty(tags)) {
+			return null;
+		}
+		return donationHaveTag.themeTag.id.in(tags);
+	}
+
+}

--- a/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationRepository.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/repository/DonationRepository.java
@@ -4,7 +4,8 @@ import com.prgrms.needit.domain.board.donation.entity.Donation;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DonationRepository extends JpaRepository<Donation, Long> {
+public interface DonationRepository
+	extends JpaRepository<Donation, Long>, DonationCustomRepository {
 
 	Optional<Donation> findByIdAndIsDeletedFalse(Long id);
 }

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -5,6 +5,7 @@ import com.prgrms.needit.common.enums.DonationStatus;
 import com.prgrms.needit.common.error.ErrorCode;
 import com.prgrms.needit.common.error.exception.NotFoundResourceException;
 import com.prgrms.needit.common.error.exception.NotMatchWriterException;
+import com.prgrms.needit.domain.board.donation.dto.DonationFilterRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationRequest;
 import com.prgrms.needit.domain.board.donation.dto.DonationResponse;
 import com.prgrms.needit.domain.board.donation.dto.DonationStatusRequest;
@@ -14,7 +15,6 @@ import com.prgrms.needit.domain.board.donation.repository.DonationTagRepository;
 import com.prgrms.needit.domain.board.donation.repository.ThemeTagRepository;
 import com.prgrms.needit.domain.member.entity.Member;
 import com.prgrms.needit.domain.member.repository.MemberRepository;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -42,9 +42,9 @@ public class DonationService {
 
 	@Transactional(readOnly = true)
 	public Page<DonationResponse> getDonations(
-		String title, String category, List<Long> tags, Pageable pageable
+		DonationFilterRequest request, Pageable pageable
 	) {
-		return donationRepository.searchAllByFilter(title, category, tags, pageable)
+		return donationRepository.searchAllByFilter(request, pageable)
 								 .map(DonationResponse::new);
 	}
 

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -14,6 +14,9 @@ import com.prgrms.needit.domain.board.donation.repository.DonationTagRepository;
 import com.prgrms.needit.domain.board.donation.repository.ThemeTagRepository;
 import com.prgrms.needit.domain.member.entity.Member;
 import com.prgrms.needit.domain.member.repository.MemberRepository;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,9 +41,16 @@ public class DonationService {
 	}
 
 	@Transactional(readOnly = true)
+	public Page<DonationResponse> getDonations(
+		String title, String category, List<Long> tags, Pageable pageable
+	) {
+		return donationRepository.searchAllByFilter(title, category, tags, pageable)
+								 .map(DonationResponse::new);
+	}
+
+	@Transactional(readOnly = true)
 	public DonationResponse getDonation(Long id) {
 		return new DonationResponse(findActiveDonation(id));
-
 	}
 
 	@Transactional


### PR DESCRIPTION
## 💻 작업 내역

- QueryDSL 이용한 기부글 목록 조회 API 구현
- `제목 검색`, `카테고리(물품나눔, 재능기부) 분류선택`, `태그(다문화, 아동&청소년...) 테마선택` 필터링
- 오프셋 기반 페이지네이션

## 🔍 특이 사항