### PR TITLE
♻️ refactor : 현재 로그인한 사용자에 대한 응답 값 수정

### DIFF
--- a/src/main/java/com/prgrms/needit/common/domain/dto/CommentResponse.java
+++ b/src/main/java/com/prgrms/needit/common/domain/dto/CommentResponse.java
@@ -15,6 +15,7 @@ public class CommentResponse {
 	private String comment;
 	private Long userId;
 	private String userName;
+	private String userEmail;
 	private String userImage;
 	private String userRole;
 	private LocalDateTime createdDate;
@@ -25,6 +26,7 @@ public class CommentResponse {
 		String comment,
 		Long userId,
 		String userName,
+		String userEmail,
 		String userImage,
 		String userRole,
 		LocalDateTime createdDate,
@@ -34,6 +36,7 @@ public class CommentResponse {
 		this.comment = comment;
 		this.userId = userId;
 		this.userName = userName;
+		this.userEmail = userEmail;
 		this.userImage = userImage;
 		this.userRole = userRole;
 		this.createdDate = createdDate;
@@ -46,6 +49,7 @@ public class CommentResponse {
 			comment.getComment(),
 			comment.getCenter().getId(),
 			comment.getCenter().getName(),
+			comment.getCenter().getEmail(),
 			comment.getCenter().getProfileImageUrl(),
 			UserType.CENTER.name(),
 			comment.getCreatedAt(),
@@ -59,6 +63,7 @@ public class CommentResponse {
 			comment.getComment(),
 			comment.getMember().getId(),
 			comment.getMember().getNickname(),
+			comment.getMember().getEmail(),
 			comment.getMember().getProfileImageUrl(),
 			UserType.MEMBER.name(),
 			comment.getCreatedAt(),

--- a/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationResponse.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/dto/DonationResponse.java
@@ -23,6 +23,7 @@ public class DonationResponse {
 	private String status;
 	private Long userId;
 	private String userName;
+	private String userEmail;
 	private String userImage;
 	private int userCnt;
 	private String boardType;
@@ -36,25 +37,19 @@ public class DonationResponse {
 		this.id = donation.getId();
 		this.title = donation.getTitle();
 		this.content = donation.getContent();
-		this.category = donation.getCategory()
-								.getType();
-		this.quality = donation.getQuality()
-							   .getType();
-		this.status = donation.getStatus()
-							  .getType();
-		this.userId = donation.getMember()
-							  .getId();
-		this.userName = donation.getMember()
-								.getNickname();
-		this.userImage = donation.getMember()
-								 .getProfileImageUrl();
+		this.category = donation.getCategory().getType();
+		this.quality = donation.getQuality().getType();
+		this.status = donation.getStatus().getType();
+		this.userId = donation.getMember().getId();
+		this.userName = donation.getMember().getNickname();
+		this.userImage = donation.getMember().getProfileImageUrl();
+		this.userEmail = donation.getMember().getEmail();
 		this.createdDate = donation.getCreatedAt();
 		this.updatedDate = donation.getUpdatedAt();
 		this.boardType = BoardType.DONATION.name();
 		this.tags = donation.getTags()
 							.stream()
-							.map(donationTag -> donationTag.getThemeTag()
-														   .getTagName())
+							.map(donationTag -> donationTag.getThemeTag().getTagName())
 							.collect(Collectors.toList());
 		this.images = donation.getImages()
 							  .stream()

--- a/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/donation/service/DonationService.java
@@ -51,17 +51,6 @@ public class DonationService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<DonationsResponse> getMyDonations() {
-		Member member = userService.getCurMember()
-								   .orElseThrow();
-
-		return donationRepository.findAllByMemberAndIsDeletedFalse(member)
-								 .stream()
-								 .map(DonationsResponse::toResponse)
-								 .collect(Collectors.toList());
-	}
-
-	@Transactional(readOnly = true)
 	public DonationResponse getDonation(Long id) {
 		return new DonationResponse(findActiveDonation(id));
 	}

--- a/src/main/java/com/prgrms/needit/domain/board/wish/dto/DonationWishResponse.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/dto/DonationWishResponse.java
@@ -22,6 +22,7 @@ public class DonationWishResponse {
 	private String status;
 	private Long userId;
 	private String userName;
+	private String userEmail;
 	private String userImage;
 	private int userCnt;
 	private String boardType;
@@ -35,23 +36,18 @@ public class DonationWishResponse {
 		this.id = wish.getId();
 		this.title = wish.getTitle();
 		this.content = wish.getContent();
-		this.category = wish.getCategory()
-							.getType();
-		this.status = wish.getStatus()
-						  .getType();
-		this.userId = wish.getCenter()
-						  .getId();
-		this.userName = wish.getCenter()
-							.getName();
-		this.userImage = wish.getCenter()
-							 .getProfileImageUrl();
+		this.category = wish.getCategory().getType();
+		this.status = wish.getStatus().getType();
+		this.userId = wish.getCenter().getId();
+		this.userName = wish.getCenter().getName();
+		this.userImage = wish.getCenter().getProfileImageUrl();
+		this.userEmail = wish.getCenter().getEmail();
 		this.createdDate = wish.getCreatedAt();
 		this.updatedDate = wish.getUpdatedAt();
 		this.boardType = BoardType.WISH.name();
 		this.tags = wish.getTags()
 						.stream()
-						.map(donationTag -> donationTag.getThemeTag()
-													   .getTagName())
+						.map(donationTag -> donationTag.getThemeTag().getTagName())
 						.collect(Collectors.toList());
 		this.images = wish.getImages()
 						  .stream()

--- a/src/main/java/com/prgrms/needit/domain/board/wish/service/DonationWishService.java
+++ b/src/main/java/com/prgrms/needit/domain/board/wish/service/DonationWishService.java
@@ -58,17 +58,6 @@ public class DonationWishService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<DonationsResponse> getMyDonationWishes() {
-		Center center = userService.getCurCenter()
-								   .orElseThrow();
-
-		return donationWishRepository.findAllByCenterAndIsDeletedFalse(center)
-									 .stream()
-									 .map(DonationsResponse::toResponse)
-									 .collect(Collectors.toList());
-	}
-
-	@Transactional(readOnly = true)
 	public DonationWishResponse getDonationWish(Long id) {
 		return new DonationWishResponse(findActiveDonationWish(id));
 	}

--- a/src/main/java/com/prgrms/needit/domain/user/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/needit/domain/user/user/controller/UserController.java
@@ -1,16 +1,12 @@
 package com.prgrms.needit.domain.user.user.controller;
 
-import com.prgrms.needit.common.domain.dto.DonationsResponse;
 import com.prgrms.needit.common.response.ApiResponse;
-import com.prgrms.needit.domain.board.donation.service.DonationService;
-import com.prgrms.needit.domain.board.wish.service.DonationWishService;
-import com.prgrms.needit.domain.user.user.dto.CurUser;
 import com.prgrms.needit.domain.user.user.dto.IsUniqueRequest;
 import com.prgrms.needit.domain.user.user.dto.IsUniqueResponse;
 import com.prgrms.needit.domain.user.user.dto.LoginRequest;
 import com.prgrms.needit.domain.user.user.dto.TokenResponse;
+import com.prgrms.needit.domain.user.user.dto.UserResponse;
 import com.prgrms.needit.domain.user.user.service.UserService;
-import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,8 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
 	private final UserService userService;
-	private final DonationService donationService;
-	private final DonationWishService donationWishService;
 
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<TokenResponse>> login(
@@ -55,18 +49,8 @@ public class UserController {
 	}
 
 	@GetMapping
-	public ResponseEntity<ApiResponse<CurUser>> getCurUser() {
-		return ResponseEntity.ok(ApiResponse.of(userService.getCurUser()));
-	}
-
-	@GetMapping("/donations")
-	public ResponseEntity<ApiResponse<List<DonationsResponse>>> getMyDonations() {
-		return ResponseEntity.ok(ApiResponse.of(donationService.getMyDonations()));
-	}
-
-	@GetMapping("/wishes")
-	public ResponseEntity<ApiResponse<List<DonationsResponse>>> getMyDonationWishes() {
-		return ResponseEntity.ok(ApiResponse.of(donationWishService.getMyDonationWishes()));
+	public ResponseEntity<ApiResponse<UserResponse>> getCurUser() {
+		return ResponseEntity.ok(ApiResponse.of(userService.getUserInfo()));
 	}
 
 }

--- a/src/main/java/com/prgrms/needit/domain/user/user/dto/UserResponse.java
+++ b/src/main/java/com/prgrms/needit/domain/user/user/dto/UserResponse.java
@@ -1,0 +1,27 @@
+package com.prgrms.needit.domain.user.user.dto;
+
+import com.prgrms.needit.common.domain.dto.DonationsResponse;
+import com.prgrms.needit.domain.user.center.dto.CentersResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserResponse {
+
+	private CurUser myProfile;
+	private List<DonationsResponse> myPost = new ArrayList<>();
+	private List<CentersResponse> myFavorite = new ArrayList<>();
+
+	public UserResponse(
+		CurUser myProfile,
+		List<DonationsResponse> myPost,
+		List<CentersResponse> myFavorite
+	) {
+		this.myProfile = myProfile;
+		this.myPost = myPost;
+		this.myFavorite = myFavorite;
+	}
+}

--- a/src/main/java/com/prgrms/needit/domain/user/user/service/UserService.java
+++ b/src/main/java/com/prgrms/needit/domain/user/user/service/UserService.java
@@ -60,8 +60,8 @@ public class UserService {
 		Optional<Member> member = getCurMember();
 		Optional<Center> center = getCurCenter();
 
-		List<DonationsResponse> myPost = null;
-		List<CentersResponse> myFavorite = null;
+		List<DonationsResponse> myPost = new ArrayList<>();
+		List<CentersResponse> myFavorite = new ArrayList<>();
 
 		if (member.isPresent()) {
 			myPost = donationRepository.findAllByMemberAndIsDeletedFalse(member.get())
@@ -78,6 +78,7 @@ public class UserService {
 										   .stream()
 										   .map(DonationsResponse::toResponse)
 										   .collect(Collectors.toList());
+			myFavorite = null;
 		}
 
 		return new UserResponse(getCurUser(), myPost, myFavorite);

--- a/src/main/java/com/prgrms/needit/domain/user/user/service/UserService.java
+++ b/src/main/java/com/prgrms/needit/domain/user/user/service/UserService.java
@@ -1,21 +1,30 @@
 package com.prgrms.needit.domain.user.user.service;
 
 import com.prgrms.needit.common.config.jwt.JwtTokenProvider;
+import com.prgrms.needit.common.domain.dto.DonationsResponse;
 import com.prgrms.needit.common.enums.UserType;
 import com.prgrms.needit.common.error.ErrorCode;
 import com.prgrms.needit.common.error.exception.NotFoundResourceException;
+import com.prgrms.needit.domain.board.donation.repository.DonationRepository;
+import com.prgrms.needit.domain.board.wish.repository.DonationWishRepository;
+import com.prgrms.needit.domain.user.center.dto.CentersResponse;
 import com.prgrms.needit.domain.user.center.entity.Center;
 import com.prgrms.needit.domain.user.center.repository.CenterRepository;
+import com.prgrms.needit.domain.user.favorite.entity.FavoriteCenter;
+import com.prgrms.needit.domain.user.favorite.repository.FavoriteCenterRepository;
+import com.prgrms.needit.domain.user.member.entity.Member;
+import com.prgrms.needit.domain.user.member.repository.MemberRepository;
 import com.prgrms.needit.domain.user.user.dto.CurUser;
 import com.prgrms.needit.domain.user.user.dto.IsUniqueRequest;
 import com.prgrms.needit.domain.user.user.dto.IsUniqueResponse;
 import com.prgrms.needit.domain.user.user.dto.LoginRequest;
 import com.prgrms.needit.domain.user.user.dto.TokenResponse;
-import com.prgrms.needit.domain.user.member.entity.Member;
-import com.prgrms.needit.domain.user.member.repository.MemberRepository;
+import com.prgrms.needit.domain.user.user.dto.UserResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -24,24 +33,16 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
 	private final MemberRepository memberRepository;
 	private final CenterRepository centerRepository;
+	private final DonationRepository donationRepository;
+	private final DonationWishRepository donationWishRepository;
+	private final FavoriteCenterRepository favoriteCenterRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final AuthenticationManagerBuilder authManagerBuilder;
-
-	public UserService(
-		MemberRepository memberRepository,
-		CenterRepository centerRepository,
-		JwtTokenProvider jwtTokenProvider,
-		AuthenticationManagerBuilder authManagerBuilder
-	) {
-		this.memberRepository = memberRepository;
-		this.centerRepository = centerRepository;
-		this.jwtTokenProvider = jwtTokenProvider;
-		this.authManagerBuilder = authManagerBuilder;
-	}
 
 	public TokenResponse login(LoginRequest login) {
 		findActiveMemberAndCenter(login.getEmail());
@@ -53,6 +54,33 @@ public class UserService {
 														  .authenticate(authenticationToken);
 
 		return jwtTokenProvider.generateToken(authentication);
+	}
+
+	public UserResponse getUserInfo() {
+		Optional<Member> member = getCurMember();
+		Optional<Center> center = getCurCenter();
+
+		List<DonationsResponse> myPost = null;
+		List<CentersResponse> myFavorite = null;
+
+		if (member.isPresent()) {
+			myPost = donationRepository.findAllByMemberAndIsDeletedFalse(member.get())
+									   .stream()
+									   .map(DonationsResponse::toResponse)
+									   .collect(Collectors.toList());
+			myFavorite = favoriteCenterRepository.findAllByMemberOrderByCreatedAt(member.get())
+												 .stream()
+												 .map(FavoriteCenter::getCenter)
+												 .map(CentersResponse::new)
+												 .collect(Collectors.toList());
+		} else if (center.isPresent()) {
+			myPost = donationWishRepository.findAllByCenterAndIsDeletedFalse(center.get())
+										   .stream()
+										   .map(DonationsResponse::toResponse)
+										   .collect(Collectors.toList());
+		}
+
+		return new UserResponse(getCurUser(), myPost, myFavorite);
 	}
 
 	public CurUser getCurUser() {
@@ -94,6 +122,20 @@ public class UserService {
 		return Optional.empty();
 	}
 
+	public IsUniqueResponse isEmailUnique(IsUniqueRequest.Email request) {
+		String inputEmail = request.getEmail();
+		boolean isUniqueMember = !memberRepository.existsByEmail(inputEmail);
+		boolean isUniqueCenter = !centerRepository.existsByEmail(inputEmail);
+
+		return new IsUniqueResponse(isUniqueMember && isUniqueCenter);
+	}
+
+	public IsUniqueResponse isNicknameUnique(IsUniqueRequest.Nickname request) {
+		return new IsUniqueResponse(
+			!memberRepository.existsByNickname(request.getNickname())
+		);
+	}
+
 	private Authentication getAuthentication() {
 		final Authentication authentication = SecurityContextHolder.getContext()
 																   .getAuthentication();
@@ -110,20 +152,6 @@ public class UserService {
 		}
 
 		return authorities.get(0);
-	}
-
-	public IsUniqueResponse isEmailUnique(IsUniqueRequest.Email request) {
-		String inputEmail = request.getEmail();
-		boolean isUniqueMember = !memberRepository.existsByEmail(inputEmail);
-		boolean isUniqueCenter = !centerRepository.existsByEmail(inputEmail);
-
-		return new IsUniqueResponse(isUniqueMember && isUniqueCenter);
-	}
-
-	public IsUniqueResponse isNicknameUnique(IsUniqueRequest.Nickname request) {
-		return new IsUniqueResponse(
-			!memberRepository.existsByNickname(request.getNickname())
-		);
 	}
 
 	private void findActiveMemberAndCenter(String email) {


### PR DESCRIPTION
## 💻 작업내역

이전 현재 로그인한 사용자의 정보를 응답할 때 사용자의 프로필 정보만 반환 했는데 프론트 쪽에서 내가 쓴 글, 관심센터 정보도 같이 주면 편할 것 같다고 해서 응답 값에 내 정보, 내가 쓴 글, 관심센터 정보 포함하여 반환하도록 수정하고 기존의  내가 쓴 글 api 인 `"users/donations"`, `"users/wishes"` 제거하였음